### PR TITLE
Add option to delete downloaded game files during uninstall

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -452,6 +452,24 @@ app.whenReady().then(async () => {
     console.log(`IPC adb:uninstallPackage called for ${packageName} on ${serial}`)
     return await adbService.uninstallPackage(serial, packageName)
   })
+  typedIpcMain.handle('adb:deleteGameFiles', async (_event, releaseName) => {
+    const downloadPath = settingsService.getDownloadPath()
+    const gamePath = join(downloadPath, releaseName)
+    console.log(`[IPC] adb:deleteGameFiles - Deleting ${gamePath}`)
+    try {
+      await fs.stat(gamePath)
+      await fs.rm(gamePath, { recursive: true, force: true })
+      console.log(`[IPC] adb:deleteGameFiles - Deleted ${gamePath}`)
+      return { deleted: true, path: gamePath }
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT') {
+        console.log(`[IPC] adb:deleteGameFiles - Path not found: ${gamePath}`)
+        return { deleted: false, path: gamePath, error: 'Game files not found in current download folder' }
+      }
+      console.error(`[IPC] adb:deleteGameFiles - Error deleting ${gamePath}:`, error)
+      return { deleted: false, path: gamePath, error: String(error) }
+    }
+  })
   typedIpcMain.on('adb:start-tracking-devices', () => {
     if (mainWindow) adbService.startTrackingDevices(mainWindow)
     else console.error('Cannot start tracking devices, mainWindow is not available.')

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -61,6 +61,8 @@ const api = {
       typedIpcRenderer.invoke('adb:get-installed-packages', serial),
     uninstallPackage: (serial: string, packageName: string): Promise<boolean> =>
       typedIpcRenderer.invoke('adb:uninstallPackage', serial, packageName),
+    deleteGameFiles: (releaseName: string): Promise<{ deleted: boolean; path: string; error?: string }> =>
+      typedIpcRenderer.invoke('adb:deleteGameFiles', releaseName),
     pingDevice: (ipAddress: string): Promise<{ reachable: boolean; responseTime?: number }> =>
       typedIpcRenderer.invoke('adb:ping-device', ipAddress),
     startTrackingDevices: (): void => typedIpcRenderer.send('adb:start-tracking-devices'),

--- a/src/renderer/src/components/GamesView.tsx
+++ b/src/renderer/src/components/GamesView.tsx
@@ -1069,7 +1069,7 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices, onTransfers, onS
       })
   }
 
-  const performUninstall = async (game: GameInfo): Promise<void> => {
+  const performUninstall = async (game: GameInfo, deleteFiles = false): Promise<void> => {
     if (!game || !game.packageName || !selectedDevice) {
       console.error(
         'Uninstall action aborted: Missing game data, package name, or selectedDevice.',
@@ -1089,6 +1089,14 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices, onTransfers, onS
       const success = await window.api.adb.uninstallPackage(selectedDevice, game.packageName)
       if (success) {
         console.log(`Uninstall: Successfully uninstalled ${game.packageName}.`)
+        if (deleteFiles && game.releaseName) {
+          const result = await window.api.adb.deleteGameFiles(game.releaseName)
+          if (result.deleted) {
+            console.log(`Uninstall: Deleted game files at ${result.path}`)
+          } else {
+            console.log(`Uninstall: Could not delete game files: ${result.error}`)
+          }
+        }
       } else {
         console.error(`Uninstall: Failed to uninstall ${game.packageName}.`)
         window.alert('Failed to uninstall the game.')
@@ -2128,11 +2136,11 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices, onTransfers, onS
       {pendingUninstall && (
         <UninstallWarningDialog
           appName={pendingUninstall.name || pendingUninstall.releaseName}
-          onConfirm={(dontShowAgain) => {
+          onConfirm={(dontShowAgain, deleteFiles) => {
             if (dontShowAgain) setSkipUninstallWarning(true)
             const game = pendingUninstall
             setPendingUninstall(null)
-            void performUninstall(game)
+            void performUninstall(game, deleteFiles)
           }}
           onCancel={() => setPendingUninstall(null)}
         />

--- a/src/renderer/src/components/UninstallWarningDialog.tsx
+++ b/src/renderer/src/components/UninstallWarningDialog.tsx
@@ -2,22 +2,17 @@ import React, { useState } from 'react'
 
 interface UninstallWarningDialogProps {
   appName: string
-  onConfirm: (dontShowAgain: boolean) => void
+  onConfirm: (dontShowAgain: boolean, deleteFiles: boolean) => void
   onCancel: () => void
 }
 
-/**
- * Confirmation shown before any "Uninstall" action. Uninstalling an app on
- * the headset also wipes its save data and settings, so this is a deliberate
- * extra step rather than a silent action - with an opt-out for users who
- * don't want to see it again (toggleable back on in Settings).
- */
 const UninstallWarningDialog: React.FC<UninstallWarningDialogProps> = ({
   appName,
   onConfirm,
   onCancel
 }) => {
   const [dontShowAgain, setDontShowAgain] = useState(false)
+  const [deleteFiles, setDeleteFiles] = useState(false)
 
   return (
     <div
@@ -78,9 +73,39 @@ const UninstallWarningDialog: React.FC<UninstallWarningDialogProps> = ({
             This cannot be undone.
           </span>
         </div>
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '8px',
+            marginBottom: '16px',
+            padding: '10px 12px',
+            fontSize: '12px',
+            color: deleteFiles ? '#ff5555' : 'rgba(var(--vrcd-neon-raw),0.7)',
+            cursor: 'pointer',
+            background: deleteFiles ? 'rgba(255,85,85,0.08)' : 'rgba(var(--vrcd-neon-raw),0.04)',
+            border: `1px solid ${deleteFiles ? 'rgba(255,85,85,0.3)' : 'rgba(var(--vrcd-neon-raw),0.12)'}`,
+            borderRadius: '6px',
+            transition: 'all 0.2s ease'
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={deleteFiles}
+            onChange={(e) => setDeleteFiles(e.target.checked)}
+            style={{ accentColor: '#ff5555', marginTop: '2px', flexShrink: 0 }}
+          />
+          <div style={{ lineHeight: 1.5 }}>
+            Also delete downloaded game files
+            <div style={{ fontSize: '10px', color: 'rgba(var(--vrcd-neon-raw),0.45)', marginTop: '2px' }}>
+              Only deletes files from your current download folder.
+              Games in other folders or previous download locations will not be affected.
+            </div>
+          </div>
+        </label>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
           <button
-            onClick={() => onConfirm(dontShowAgain)}
+            onClick={() => onConfirm(dontShowAgain, deleteFiles)}
             style={{
               background: 'transparent',
               border: '2px solid rgba(255,85,85,0.7)',

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -237,6 +237,7 @@ export interface AdbAPI {
   getInstalledPackages: (serial: string) => Promise<PackageInfo[]>
   getApplicationLabel: (serial: string, packageName: string) => Promise<string | null>
   uninstallPackage: (serial: string, packageName: string) => Promise<boolean>
+  deleteGameFiles: (releaseName: string) => Promise<{ deleted: boolean; path: string; error?: string }>
   startTrackingDevices: (mainWindow?: BrowserWindow) => void
   stopTrackingDevices: () => void
   getUserName: (serial: string) => Promise<string>

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -52,6 +52,7 @@ export interface IPCChannels {
   'adb:get-device-ip': DefineChannel<[serial: string], string | null>
   'adb:get-installed-packages': DefineChannel<[serial: string], PackageInfo[]>
   'adb:uninstallPackage': DefineChannel<[serial: string, packageName: string], boolean>
+  'adb:deleteGameFiles': DefineChannel<[releaseName: string], { deleted: boolean; path: string; error?: string }>
   'adb:get-application-label': DefineChannel<[serial: string, packageName: string], string | null>
   'adb:get-user-name': DefineChannel<[serial: string], string>
   'adb:set-user-name': DefineChannel<[serial: string, name: string], void>


### PR DESCRIPTION
The uninstall confirmation dialog now includes a checkbox to also delete the game's downloaded files from the current download folder. A warning explains that only the current download folder is affected — games in other folders or previous download locations will not be touched.
