### PR TITLE
Fix ADB extraction hang and improve rclone download error messages

### DIFF
--- a/src/main/services/dependencyService.ts
+++ b/src/main/services/dependencyService.ts
@@ -266,7 +266,8 @@ class DependencyService {
     archivePath: string,
     destDir: string,
     progressName: string,
-    progressCallback?: ProgressCallback
+    progressCallback?: ProgressCallback,
+    timeoutMs: number = 120_000
   ): Promise<Error | null> {
     const sevenZipPath = this.get7zPath()
     console.log(`Using bundled 7zip at ${sevenZipPath} for extraction.`)
@@ -277,11 +278,33 @@ class DependencyService {
     // Tolerate benign 7-Zip stderr (e.g. dylibs injected by macOS tweak
     // frameworks); a real ERROR still rejects and success is confirmed by the
     // caller's file existence check below.
-    const captured = await awaitSevenZipStream(stream, (percent) =>
+    const extractionPromise = awaitSevenZipStream(stream, (percent) =>
       progressCallback?.(this.status, { name: progressName, percentage: percent })
     )
-    console.log(`Archive extracted to ${destDir}`)
-    return captured
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        try {
+          stream.destroy()
+        } catch { /* stream may already be closed */ }
+        reject(
+          new Error(
+            `Extraction timed out after ${Math.round(timeoutMs / 1000)}s. ` +
+              `This usually means the 7-Zip process could not start or the archive is corrupt. ` +
+              `Antivirus software blocking executables in AppData is a common cause on Windows.`
+          )
+        )
+      }, timeoutMs)
+    })
+
+    try {
+      const captured = await Promise.race([extractionPromise, timeoutPromise])
+      console.log(`Archive extracted to ${destDir}`)
+      return captured
+    } finally {
+      clearTimeout(timeoutId)
+    }
   }
 
   // --- rclone ---
@@ -641,6 +664,20 @@ class DependencyService {
 
       console.log(`adb platform-tools download complete: ${tempArchivePath}`)
       progressCallback?.(this.status, { name: 'adb', percentage: 100 })
+
+      // Validate the downloaded archive before trying to extract it. A
+      // corrupt, truncated, or intercepted download (e.g. a captive-portal
+      // HTML page returned with HTTP 200) would make 7-Zip hang or fail with
+      // a misleading error. Platform-tools zips are always >5 MB.
+      const downloadedStat = await fsPromises.stat(tempArchivePath)
+      if (downloadedStat.size < 1024 * 1024) {
+        throw new Error(
+          `Downloaded ADB archive is too small (${downloadedStat.size} bytes) — ` +
+            `the file is likely corrupt or your network returned an error page. ` +
+            `Check your internet connection and try again.`
+        )
+      }
+      console.log(`Downloaded archive size: ${downloadedStat.size} bytes`)
 
       // --- Extraction Step using SevenZip ---
       tempExtractDir = join(app.getPath('temp'), `adb-extract-${Date.now()}`)

--- a/src/main/services/download/downloadProcessor.ts
+++ b/src/main/services/download/downloadProcessor.ts
@@ -235,6 +235,12 @@ export class DownloadProcessor {
       : join(item.downloadPath, item.releaseName)
     this.queueManager.updateItem(item.releaseName, { downloadPath: downloadPath })
 
+    // Declared outside `try` so the catch block can inspect transfer state
+    // and produce a targeted error message (e.g. "server returned no data").
+    let lastProgress = -1
+    let lastSpeed = ''
+    let statsCount = 0
+
     try {
       await fs.mkdir(downloadPath, { recursive: true })
 
@@ -395,9 +401,6 @@ export class DownloadProcessor {
       })
 
       // Parse rclone JSON log output for progress
-      let lastProgress = -1
-      let lastSpeed = ''
-      let statsCount = 0
       if (rcloneProcess.all) {
         let lineBuffer = ''
         rcloneProcess.all.on('data', (chunk: Buffer) => {
@@ -627,6 +630,16 @@ export class DownloadProcessor {
         errorMessage = String(error)
       }
       errorMessage = redactKey(errorMessage).substring(0, 500)
+
+      // rclone received stats but transferred zero bytes — the download source
+      // is unreachable or returned an empty directory listing. Provide a clear
+      // message instead of the raw "exit code 1".
+      if (statsCount > 0 && lastProgress <= 0) {
+        errorMessage =
+          'Download source returned no data. The download server may be temporarily ' +
+          'unavailable, or the game may have been removed from the server. ' +
+          'Check your internet connection and try again later.'
+      }
 
       // Normalise ENOSPC / "no space left" that surfaces mid-download (rclone
       // writes fail after the pre-flight disk-space check passed).

--- a/src/renderer/src/components/AppLayout.tsx
+++ b/src/renderer/src/components/AppLayout.tsx
@@ -530,12 +530,18 @@ const MainContent: React.FC<MainContentProps> = ({
     } else if (dependencyStatus?.rclone.downloading && dependencyProgress) {
       progressText = `Setting up ${dependencyProgress.name}... ${dependencyProgress.percentage}%`
       if (dependencyProgress.name === 'rclone-extract') {
-        progressText = `Extracting ${dependencyProgress.name.replace('-extract', '')}...`
+        progressText =
+          dependencyProgress.percentage > 0
+            ? `Extracting ${dependencyProgress.name.replace('-extract', '')}... ${dependencyProgress.percentage}%`
+            : `Extracting ${dependencyProgress.name.replace('-extract', '')}...`
       }
     } else if (dependencyStatus?.adb.downloading && dependencyProgress) {
       progressText = `Setting up ${dependencyProgress.name}... ${dependencyProgress.percentage}%`
       if (dependencyProgress.name === 'adb-extract') {
-        progressText = `Extracting ${dependencyProgress.name.replace('-extract', '')}...`
+        progressText =
+          dependencyProgress.percentage > 0
+            ? `Extracting ${dependencyProgress.name.replace('-extract', '')}... ${dependencyProgress.percentage}%`
+            : `Extracting ${dependencyProgress.name.replace('-extract', '')}...`
       }
     } else if (
       dependencyStatus &&


### PR DESCRIPTION
Two separate user-reported issues:

1. ADB extraction hangs indefinitely during dependency setup ("Extracting adb..." never progresses). Root causes: extractWithSevenZip had no timeout, so a stuck 7-Zip process (antivirus blocking, corrupt archive) would hang forever. Also, a captive-portal or CDN error returning an HTML page with HTTP 200 would produce a tiny file that 7-Zip can't process. Fixes: add a 2-minute timeout with stream.destroy() cleanup, validate downloaded archive is >1 MB before extraction, and show extraction percentage in the UI instead of a static "Extracting..." message.

2. rclone downloads fail repeatedly with "exit code 1" when the download server returns no data (bytes=0, totalBytes=0). The raw execa error message was unhelpful. Fix: move stats-tracking variables outside the try block so the catch block can detect zero-transfer failures and surface a clear message about the server being unavailable.