### PR TITLE
Fix dependency initialization error handling

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -219,6 +219,17 @@ function createWindow(): void {
       try {
         const initialized = await dependencyService.initialize(sendDependencyProgress)
         if (initialized === 'INITIALIZING') {
+          console.log('DependencyService already initializing, skipping duplicate request.')
+          return
+        }
+        if (initialized === 'ERROR') {
+          console.error('Dependency initialization returned ERROR status.')
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            typedWebContentsSend.send(mainWindow, 'dependency-setup-error', {
+              message: 'One or more dependencies failed to initialize',
+              status: dependencyService.getStatus()
+            })
+          }
           return
         }
         console.log('Dependency initialization complete. Sending status.')
@@ -275,15 +286,13 @@ function createWindow(): void {
           } catch (serviceInitError) {
             console.error('Error initializing dependent services:', serviceInitError)
             dependencyService.setDependencyServiceStatus('ERROR')
-            // Optionally notify the renderer about this failure
-            // if (mainWindow && !mainWindow.isDestroyed()) {
-            //   typedWebContentsSend.send(mainWindow, 'service-init-error', {
-            //     message:
-            //       serviceInitError instanceof Error
-            //         ? serviceInitError.message
-            //         : 'Unknown service initialization error'
-            //   })
-            // }
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              typedWebContentsSend.send(
+                mainWindow,
+                'dependency-setup-complete',
+                dependencyService.getStatus()
+              )
+            }
           }
           // -----------------------------------------------------------
         }

--- a/src/main/services/gameService.ts
+++ b/src/main/services/gameService.ts
@@ -122,9 +122,8 @@ class GameService extends EventEmitter implements GamesAPI {
       console.error('Error initializing game service:', error)
       this.status = 'ERROR'
       return 'ERROR'
-    } finally {
-      this.status = 'INITIALIZED'
     }
+    this.status = 'INITIALIZED'
     return 'INITIALIZED'
   }
 


### PR DESCRIPTION
- Remove finally block in GameService.initialize() that unconditionally set status to INITIALIZED, silently overriding ERROR status from the catch block
- Send dependency-setup-error to renderer when dependencyService.initialize() returns ERROR, instead of silently returning
- Send dependency-setup-complete (with error status) to renderer when service initialization throws, instead of leaving the UI stuck in a loading state forever
