### PR TITLE
Add server on/off toggle inside the Server & Remotes dialog

### DIFF
--- a/src/renderer/src/components/GamesView.tsx
+++ b/src/renderer/src/components/GamesView.tsx
@@ -1734,7 +1734,11 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices, onTransfers, onS
           <DialogBody style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', padding: 0 }}>
             <DialogTitle style={{ padding: '16px 24px', borderBottom: '1px solid rgba(var(--vrcd-neon-raw),0.15)' }}>Server & Remotes</DialogTitle>
             <DialogContent style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', padding: '16px 24px' }}>
-              <MirrorManagement />
+              <MirrorManagement
+                serverConfigured={hasServerConfig}
+                serverActive={isServerMode}
+                onToggleServer={setServerMode}
+              />
             </DialogContent>
             <DialogActions style={{ padding: '12px 24px', borderTop: '1px solid rgba(var(--vrcd-neon-raw),0.15)' }}>
               <Button appearance="secondary" onClick={() => setShowMirrorMgmt(false)}>Close</Button>

--- a/src/renderer/src/components/MirrorManagement.tsx
+++ b/src/renderer/src/components/MirrorManagement.tsx
@@ -107,7 +107,20 @@ const useStyles = makeStyles({
   }
 })
 
-const MirrorManagement: React.FC = () => {
+interface MirrorManagementProps {
+  /** True when a server (public JSON or rclone config) has been configured. */
+  serverConfigured?: boolean
+  /** True when server mode is currently active (configured AND not toggled off). */
+  serverActive?: boolean
+  /** Toggle server mode on/off without wiping the saved server credentials. */
+  onToggleServer?: (on: boolean) => void
+}
+
+const MirrorManagement: React.FC<MirrorManagementProps> = ({
+  serverConfigured = false,
+  serverActive = false,
+  onToggleServer
+}) => {
   const styles = useStyles()
   const { t } = useLanguage()
   const {
@@ -287,17 +300,35 @@ const MirrorManagement: React.FC = () => {
               )}
               <Text style={{ color: getServerStatusColor() }}>{getServerStatusText()}</Text>
             </div>
-            {activeMirror && hasPublicConfig && (
-              <Button
-                appearance="subtle"
-                size="small"
-                icon={<RadioButtonRegular />}
-                onClick={() => clearActiveMirror()}
-                title="Switch back to the public server"
-              >
-                Use Public Server
-              </Button>
-            )}
+            <div style={{ display: 'flex', alignItems: 'center', gap: tokens.spacingHorizontalS }}>
+              {activeMirror && hasPublicConfig && (
+                <Button
+                  appearance="subtle"
+                  size="small"
+                  icon={<RadioButtonRegular />}
+                  onClick={() => clearActiveMirror()}
+                  title="Switch back to the public server"
+                >
+                  Use Public Server
+                </Button>
+              )}
+              {/* Toggle server mode on/off without wiping the saved credentials */}
+              {serverConfigured && onToggleServer && (
+                <Button
+                  appearance="primary"
+                  size="small"
+                  icon={serverActive ? <DismissCircleRegular /> : <PlayRegular />}
+                  onClick={() => onToggleServer(!serverActive)}
+                  title={
+                    serverActive
+                      ? 'Turn the server off and drop back to the sideloader (keeps your saved server info)'
+                      : 'Turn the configured server back on'
+                  }
+                >
+                  {serverActive ? 'Switch to Sideloader' : 'Switch to Server Mode'}
+                </Button>
+              )}
+            </div>
           </div>
         </CardPreview>
       </Card>


### PR DESCRIPTION
The mode toggle previously only lived in the library sidebar and the sideloader deck, which wasn't where people look for it. Surface it in the Server & Remotes dialog next to the "Active method" line as well.

- MirrorManagement takes serverConfigured / serverActive / onToggleServer props and renders a "Switch to Sideloader" / "Switch to Server Mode" button in the active-method status card when a server is configured.
- GamesView passes the existing mode state/toggle down to it.
