### PR TITLE
Sanitize and validate server Base URI to prevent rclone parse failures

### DIFF
--- a/src/main/services/settingsService.ts
+++ b/src/main/services/settingsService.ts
@@ -6,6 +6,7 @@ import {
   ExistingDownloadAction,
   WindowBounds
 } from '@shared/types'
+import { sanitizeBaseUri } from '@shared/serverConfig'
 import { app, nativeTheme } from 'electron'
 import { join } from 'path'
 import { existsSync, readFileSync, writeFileSync } from 'fs'
@@ -84,14 +85,16 @@ class SettingsService extends EventEmitter implements SettingsAPI {
     // No bundled/hardcoded server. When nothing has been configured the app
     // runs as a pure sideloader; a server (public vrSrc JSON or an rclone
     // config) only comes into play once the user adds one via Manage Remotes.
-    const uri = this.settings.serverConfig?.baseUri ?? ''
+    // Sanitize on read so a previously-saved bad value (e.g. a URL with
+    // wrapping quotes) is healed before it ever reaches rclone.
+    const uri = sanitizeBaseUri(this.settings.serverConfig?.baseUri ?? '')
     const pwd = this.settings.serverConfig?.password ?? ''
     return { baseUri: uri, password: pwd }
   }
 
   setServerConfig(config: ServerConfigInfo): void {
     this.settings.serverConfig = {
-      baseUri: config.baseUri ?? '',
+      baseUri: sanitizeBaseUri(config.baseUri ?? ''),
       password: config.password ?? ''
     }
     this.saveSettings()

--- a/src/renderer/src/components/ServerConfigSettings.tsx
+++ b/src/renderer/src/components/ServerConfigSettings.tsx
@@ -58,33 +58,63 @@ const ServerConfigSettings: React.FC = () => {
     setPassword(serverConfig.password)
   }, [serverConfig.baseUri, serverConfig.password])
 
+  // Parse a JSON blob and, if it carries string baseUri + password, copy the
+  // values into the two fields. Returns true when it applied something.
+  const tryApplyJson = (text: string): boolean => {
+    const trimmed = text.trim()
+    if (!trimmed) return false
+    try {
+      const parsed = JSON.parse(trimmed) as { baseUri?: unknown; password?: unknown }
+      if (typeof parsed.baseUri === 'string' && typeof parsed.password === 'string') {
+        setBaseUri(parsed.baseUri)
+        setPassword(parsed.password)
+        return true
+      }
+    } catch {
+      // Not valid JSON (yet) — ignore while the user is still typing/pasting.
+    }
+    return false
+  }
+
+  const handleJsonChange = (value: string): void => {
+    setPastedJson(value)
+    // Auto-fill the fields the instant the pasted text is valid JSON, so a
+    // paste "just works" without a second button click.
+    if (tryApplyJson(value)) setLocalError(null)
+  }
+
   const handleParseJson = (): void => {
     setLocalError(null)
-    const trimmed = pastedJson.trim()
-    if (!trimmed) {
+    if (!pastedJson.trim()) {
       setLocalError('Paste a JSON snippet first')
       return
     }
-    try {
-      const parsed = JSON.parse(trimmed) as { baseUri?: unknown; password?: unknown }
-      if (typeof parsed.baseUri !== 'string' || typeof parsed.password !== 'string') {
-        setLocalError('JSON must contain string "baseUri" and "password" fields')
-        return
-      }
-      setBaseUri(parsed.baseUri)
-      setPassword(parsed.password)
-      setPastedJson('')
-    } catch (err) {
-      console.error('Failed to parse pasted JSON:', err)
-      setLocalError('Pasted text is not valid JSON')
+    if (!tryApplyJson(pastedJson)) {
+      setLocalError('JSON must contain string "baseUri" and "password" fields')
     }
   }
 
   const handleSave = async (): Promise<void> => {
     setLocalError(null)
     setSaveSuccess(false)
-    const cleanUri = sanitizeBaseUri(baseUri)
-    const cleanPassword = password.trim()
+
+    // Resolve the values to save: prefer the fields, but fall back to the
+    // pasted JSON blob if the user pasted and hit Save without the fields
+    // populating.
+    let rawUri = baseUri
+    let rawPass = password
+    if ((!rawUri.trim() || !rawPass.trim()) && pastedJson.trim()) {
+      try {
+        const parsed = JSON.parse(pastedJson.trim()) as { baseUri?: unknown; password?: unknown }
+        if (typeof parsed.baseUri === 'string') rawUri = parsed.baseUri
+        if (typeof parsed.password === 'string') rawPass = parsed.password
+      } catch {
+        // Not valid JSON — fall through to the validation below.
+      }
+    }
+
+    const cleanUri = sanitizeBaseUri(rawUri)
+    const cleanPassword = rawPass.trim()
     if (!cleanUri || !cleanPassword) {
       setLocalError('Both baseUri and password are required')
       return
@@ -94,9 +124,10 @@ const ServerConfigSettings: React.FC = () => {
       return
     }
     try {
-      // Reflect the sanitized value back into the field so the user sees what
+      // Reflect the sanitized values back into the fields so the user sees what
       // was actually saved (e.g. wrapping quotes stripped).
       setBaseUri(cleanUri)
+      setPassword(cleanPassword)
       await setServerConfig({ baseUri: cleanUri, password: cleanPassword })
       setSaveSuccess(true)
       setTimeout(() => setSaveSuccess(false), 3000)
@@ -121,7 +152,8 @@ const ServerConfigSettings: React.FC = () => {
             style={{ display: 'flex', flexDirection: 'column', gap: tokens.spacingVerticalM }}
           >
             <Text size={200} style={{ color: tokens.colorNeutralForeground2 }}>
-              Paste the full JSON or fill in the fields. Credentials are stored locally.
+              Paste the full JSON — the fields below fill in automatically — then click Save. Or
+              fill in the fields yourself. Credentials are stored locally.
             </Text>
 
             <div style={{ display: 'flex', flexDirection: 'column', gap: tokens.spacingVerticalXS }}>
@@ -130,13 +162,13 @@ const ServerConfigSettings: React.FC = () => {
               </Text>
               <Textarea
                 value={pastedJson}
-                onChange={(_, data) => setPastedJson(data.value)}
+                onChange={(_, data) => handleJsonChange(data.value)}
                 placeholder='{"baseUri":"https://...","password":"..."}'
                 rows={2}
                 resize="vertical"
               />
               <Button size="small" onClick={handleParseJson} appearance="subtle">
-                Apply JSON to fields
+                Fill fields from JSON
               </Button>
             </div>
 

--- a/src/renderer/src/components/ServerConfigSettings.tsx
+++ b/src/renderer/src/components/ServerConfigSettings.tsx
@@ -20,6 +20,7 @@ import {
   DismissCircleRegular
 } from '@fluentui/react-icons'
 import { useSettings } from '../hooks/useSettings'
+import { sanitizeBaseUri, isValidBaseUri } from '@shared/serverConfig'
 
 const useStyles = makeStyles({
   row: {
@@ -82,12 +83,21 @@ const ServerConfigSettings: React.FC = () => {
   const handleSave = async (): Promise<void> => {
     setLocalError(null)
     setSaveSuccess(false)
-    if (!baseUri.trim() || !password.trim()) {
+    const cleanUri = sanitizeBaseUri(baseUri)
+    const cleanPassword = password.trim()
+    if (!cleanUri || !cleanPassword) {
       setLocalError('Both baseUri and password are required')
       return
     }
+    if (!isValidBaseUri(cleanUri)) {
+      setLocalError('Base URI must be a valid URL, e.g. https://example.com/ (no quotes)')
+      return
+    }
     try {
-      await setServerConfig({ baseUri: baseUri.trim(), password: password.trim() })
+      // Reflect the sanitized value back into the field so the user sees what
+      // was actually saved (e.g. wrapping quotes stripped).
+      setBaseUri(cleanUri)
+      await setServerConfig({ baseUri: cleanUri, password: cleanPassword })
       setSaveSuccess(true)
       setTimeout(() => setSaveSuccess(false), 3000)
     } catch (err) {

--- a/src/shared/serverConfig.ts
+++ b/src/shared/serverConfig.ts
@@ -1,0 +1,45 @@
+/**
+ * Helpers for normalizing and validating the public server Base URI.
+ *
+ * The Base URI is handed verbatim to rclone's `--http-url` flag. rclone parses
+ * it as a URL, so stray wrapping quotes (a common copy/paste mistake, e.g.
+ * pasting `"https://example.com/"` from a JSON snippet) make rclone fail with
+ * `first path segment in URL cannot contain colon`. These helpers strip that
+ * kind of noise and reject values that aren't real http(s) URLs before they can
+ * be saved.
+ */
+
+/**
+ * Strip surrounding whitespace and any wrapping single/double quotes from a
+ * Base URI. Safe to call on already-clean values (returns them unchanged).
+ */
+export function sanitizeBaseUri(raw: string): string {
+  let value = (raw ?? '').trim()
+  // Remove one or more layers of wrapping matching quotes: "'https://x/'" etc.
+  let previous: string
+  do {
+    previous = value
+    const first = value[0]
+    const last = value[value.length - 1]
+    if (value.length >= 2 && (first === '"' || first === "'") && last === first) {
+      value = value.slice(1, -1).trim()
+    }
+  } while (value !== previous)
+  return value
+}
+
+/**
+ * Returns true when `value` is a well-formed absolute http(s) URL. An empty
+ * string is considered invalid (callers enforce "required" separately when
+ * they need a stricter message).
+ */
+export function isValidBaseUri(value: string): boolean {
+  if (!value) return false
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    return false
+  }
+  return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+}


### PR DESCRIPTION
The public server Base URI is passed verbatim to rclone's --http-url flag. When a user pastes or types the URL wrapped in quotes (e.g. "https://example.com/") the previous code only trimmed whitespace, so the quotes were saved as-is. rclone then failed with a cryptic "first path segment in URL cannot contain colon" during game list sync, surfaced only much later as a failed refresh.

Add a shared sanitizer that strips wrapping single/double quotes and a validator that requires a well-formed http(s) URL:

- src/shared/serverConfig.ts: sanitizeBaseUri + isValidBaseUri helpers
- ServerConfigSettings: sanitize + validate on save, show a clear error and reflect the cleaned value back into the field
- settingsService: sanitize on both read and write as a backstop, so already-saved bad values self-heal before reaching rclone