### PR TITLE
Fix card size slider so the whole range works and default is medium

### DIFF
--- a/src/renderer/src/components/GamesView.tsx
+++ b/src/renderer/src/components/GamesView.tsx
@@ -2327,7 +2327,7 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices, onTransfers, onS
                 {prefs.viewMode === 'cards' ? (
                   <div
                     className="games-card-grid"
-                    style={{ '--card-min-w': `${140 + Math.round(prefs.cardSize * 1.4)}px` } as React.CSSProperties}
+                    style={{ '--card-min-w': `${140 + Math.round(prefs.cardSize * 0.7)}px` } as React.CSSProperties}
                   >
                     {rows.map((row) => {
                       const game = row.original


### PR DESCRIPTION
## Problem

The **Card Size** slider (card view options) felt broken: the top half did nothing, and cards defaulted to their biggest size instead of a medium one.

## Cause

`GamesView.tsx` mapped `cardSize` (0–100) to the card grid's min-width as `140 + cardSize * 1.4` → **140–280px**. The grid uses `minmax(var(--card-min-w), 1fr)`, so once min-width climbs past ~210px the grid collapses toward a single full-width column and further increases stop changing anything visible. That made the slider's **upper half a dead zone**, with the midpoint (`50 → 210px`) already at the ceiling — so the default landed on max size.

## Fix

Halve the multiplier (`1.4 → 0.7`) so the full slider range stays below the collapse point:

| cardSize | before | after |
|---|---|---|
| 0 (min) | 140px | 140px |
| 50 (default) | 210px (maxed) | **175px (medium)** |
| 100 (max) | 280px (dead) | **210px** |

- The old midpoint size (210px) is now the slider's **largest end**.
- The default sits mid-range again — a medium card, not the biggest.
- The **entire slider** now affects card size; no dead upper half.

One-line change. `typecheck:web` passes.

Note: the exact numbers (175px default / 210px max) are easy to nudge if you'd prefer the default a touch smaller or larger — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqLLq51yZKEsYqtKcdQgBN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqLLq51yZKEsYqtKcdQgBN)_