### PR TITLE
fix: stop npm test from choking on node:test suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "example.com",
   "homepage": "https://electron-vite.org",
   "scripts": {
-    "test": "node --test src/main/services/download/*.test.mjs",
+    "test:node": "node --test src/main/services/download/*.test.mjs",
     "format": "prettier --write .",
     "lint": "eslint --cache .",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+// Vitest runs the TypeScript unit tests. The Node-based `*.test.mjs` suites
+// under src/main/services/download use the node:test runner instead and are
+// executed via `npm run test:node`, so they are excluded from Vitest's globs
+// here to prevent it from trying (and failing) to collect them.
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts']
+  }
+})


### PR DESCRIPTION
Merging the storage-recovery and archive-discovery work left package.json with a duplicate "test" key: an added 'node --test *.test.mjs' entry alongside the existing 'vitest run'. The last key wins, so 'npm test' ran vitest, which then tried to collect the node:test .mjs suites and failed.

Give the node suites their own script and scope Vitest to the TypeScript tests so the two runners stop colliding:
- rename the duplicate to test:node
- add vitest.config.ts limiting Vitest to src/**/*.test.ts

npm test (vitest) and npm run test:node both pass; typecheck and build are unaffected.