### PR TITLE
Fix card-size slider dead zone (only changed near 100%)

### DIFF
--- a/src/renderer/src/assets/games-view.css
+++ b/src/renderer/src/assets/games-view.css
@@ -401,29 +401,24 @@
 }
 
 /* ── Card grid view ────────────────────────────────────────────── */
-/* The size slider sets --card-cols (the desired cards per row). The track size
-   is the exact width that many columns need, so auto-fill lands on that count
-   at any window width. max() keeps a card from dropping below --card-min, so
-   narrow windows quietly fall back to fewer columns instead of unreadable
-   slivers. Driving the count this way — rather than sweeping a min-width — is
-   what stops the top half of the slider from being a dead zone: a linear
-   min-width maps to columns reciprocally, so its steps bunch up at the small
-   end and leave the large end with nothing left to change. */
+/* The size slider sets --card-cols (cards per row) via cardColumns(); the grid
+   renders exactly that many equal-width columns, so every slider position maps
+   to a distinct layout.
+
+   The previous version used auto-fill with minmax(max(--card-min, <target>), 1fr).
+   That floor meant that whenever the target card width fell below --card-min
+   (140px) — which is most of the slider's travel, and nearly all of it on a
+   narrow window — auto-fill ignored --card-cols and just packed 140px columns,
+   pinning the count to a constant. That was the "slider does nothing until the
+   very end" dead zone. Driving the column count directly removes it entirely.
+
+   minmax(0, 1fr) lets the columns shrink to share the row on narrow windows
+   without overflowing (0 as the min floor, 1fr to split the space evenly). */
 .games-card-grid {
   --card-cols: 7;
   --card-gap: 12px;
-  --card-min: 140px;
   display: grid;
-  grid-template-columns: repeat(
-    auto-fill,
-    minmax(
-      max(
-        var(--card-min),
-        calc((100% - (var(--card-cols) - 1) * var(--card-gap)) / var(--card-cols))
-      ),
-      1fr
-    )
-  );
+  grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
   gap: var(--card-gap);
   padding: 12px;
   overflow-y: auto;


### PR DESCRIPTION
## Problem
On card view, the **Card Size** slider did nothing across most of its range — the layout only changed right at the top (~99–100%). On a narrower window it was even worse: effectively no change until the very end.

## Cause
`.games-card-grid` sized columns with:

```css
grid-template-columns: repeat(
  auto-fill,
  minmax(max(var(--card-min) /* 140px */, calc(<target width for --card-cols>)), 1fr)
);
```

`auto-fill` packs as many columns of width `max(140px, target)` as fit. Whenever the target card width falls **below** 140px — which is most of the slider's travel, and nearly all of it on a narrow window — the `max()` clamps to 140px and `auto-fill` ignores `--card-cols` entirely, pinning the column count to a constant. The count only starts following the slider once the cards are large enough that the target width exceeds 140px, i.e. near the top. That's the dead zone.

## Fix
Render exactly `--card-cols` columns:

```css
grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
```

Every slider position now maps to a distinct column count (`cardColumns()` spans 12→3 across 0→100), so card size changes smoothly across the whole slider. `minmax(0, 1fr)` lets columns shrink to share the row on narrow windows without overflowing. The now-unused `--card-min` variable is dropped.

## Verification
- `typecheck` (web): 0 errors
- `electron-vite build`: succeeds (renderer + CSS bundle)
- CSS-only change; behaviour needs a quick visual confirm in-app (drag the slider end-to-end — column count should step the whole way).

Note: at the far "smallest" end this now allows up to 12 columns, which on a small window makes cards quite small — that's the slider working as intended, but if you'd prefer a tighter range it's a one-line tweak to `CARD_COLS_MIN`/`CARD_COLS_MAX`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgdF5ZAVk4pQA969JNXfHK)_