### PR TITLE
fix(games): make the card-size slider responsive across its full range

### DIFF
--- a/src/renderer/src/assets/games-view.css
+++ b/src/renderer/src/assets/games-view.css
@@ -401,29 +401,24 @@
 }
 
 /* ── Card grid view ────────────────────────────────────────────── */
-/* The size slider sets --card-cols (the desired cards per row). The track size
-   is the exact width that many columns need, so auto-fill lands on that count
-   at any window width. max() keeps a card from dropping below --card-min, so
-   narrow windows quietly fall back to fewer columns instead of unreadable
-   slivers. Driving the count this way — rather than sweeping a min-width — is
-   what stops the top half of the slider from being a dead zone: a linear
-   min-width maps to columns reciprocally, so its steps bunch up at the small
-   end and leave the large end with nothing left to change. */
+/* The size slider sets --card-cols (cards per row) via cardColumns(); the grid
+   renders exactly that many equal-width columns, so every slider position maps
+   to a distinct layout.
+
+   The previous version used auto-fill with minmax(max(--card-min, <target>), 1fr).
+   That floor meant that whenever the target card width fell below --card-min
+   (140px) — which is most of the slider's travel, and nearly all of it on a
+   narrow window — auto-fill ignored --card-cols and just packed 140px columns,
+   pinning the count to a constant. That was the "slider does nothing until the
+   very end" dead zone. Driving the column count directly removes it entirely.
+
+   minmax(0, 1fr) lets the columns shrink to share the row on narrow windows
+   without overflowing (0 as the min floor, 1fr to split the space evenly). */
 .games-card-grid {
   --card-cols: 7;
   --card-gap: 12px;
-  --card-min: 140px;
   display: grid;
-  grid-template-columns: repeat(
-    auto-fill,
-    minmax(
-      max(
-        var(--card-min),
-        calc((100% - (var(--card-cols) - 1) * var(--card-gap)) / var(--card-cols))
-      ),
-      1fr
-    )
-  );
+  grid-template-columns: repeat(var(--card-cols), minmax(0, 1fr));
   gap: var(--card-gap);
   padding: 12px;
   overflow-y: auto;


### PR DESCRIPTION
The card grid used auto-fill with
minmax(max(--card-min, <target-width>), 1fr). Whenever the target card width fell below --card-min (140px) — which is most of the slider's travel, and nearly all of it on a narrow window — auto-fill ignored --card-cols and simply packed 140px columns, pinning the column count to a constant. That produced the long-standing "slider does nothing until the very end" dead zone.

Render exactly --card-cols columns instead:
repeat(var(--card-cols), minmax(0, 1fr)). Every slider position now maps to a distinct column count (cardColumns() spans 12→3 across 0→100), so card size changes smoothly the whole way. minmax(0, 1fr) lets columns shrink to share the row on narrow windows without overflowing. The unused --card-min variable is dropped.