### PR TITLE
feat(download): make release.manifest mismatch a warning, not a hard …

### DIFF
--- a/src/main/services/download/extractionProcessor.ts
+++ b/src/main/services/download/extractionProcessor.ts
@@ -230,9 +230,17 @@ export class ExtractionProcessor {
       await this.extractNestedArchives(downloadPath, item.releaseName)
 
       const manifestCheck = await this.verifyAgainstReleaseManifest(downloadPath, item.releaseName)
+      // A mismatch is a warning, not a hard failure: a release can ship a wrong
+      // manifest, and the user may want to install regardless. Record it (and
+      // clear any stale warning on success); the pipeline skips auto-install for
+      // a warned item so the user explicitly chooses whether to install anyway.
+      this.queueManager.updateItem(item.releaseName, {
+        manifestWarning: manifestCheck.ok ? undefined : manifestCheck.error
+      })
       if (!manifestCheck.ok) {
-        this.updateItemStatus(item.releaseName, 'Error', 100, manifestCheck.error)
-        return false
+        console.warn(
+          `[ExtractProc] ${manifestCheck.error} — completing ${item.releaseName} with a warning; auto-install skipped.`
+        )
       }
 
       // Update final status to Completed
@@ -454,9 +462,17 @@ export class ExtractionProcessor {
       await this.extractNestedArchives(downloadPath, item.releaseName)
 
       const manifestCheck = await this.verifyAgainstReleaseManifest(downloadPath, item.releaseName)
+      // A mismatch is a warning, not a hard failure: a release can ship a wrong
+      // manifest, and the user may want to install regardless. Record it (and
+      // clear any stale warning on success); the pipeline skips auto-install for
+      // a warned item so the user explicitly chooses whether to install anyway.
+      this.queueManager.updateItem(item.releaseName, {
+        manifestWarning: manifestCheck.ok ? undefined : manifestCheck.error
+      })
       if (!manifestCheck.ok) {
-        this.updateItemStatus(item.releaseName, 'Error', 100, manifestCheck.error)
-        return false
+        console.warn(
+          `[ExtractProc] ${manifestCheck.error} — completing ${item.releaseName} with a warning; auto-install skipped.`
+        )
       }
 
       // Update final status to Completed
@@ -570,17 +586,18 @@ export class ExtractionProcessor {
   }
 
   /**
-   * Verify the extracted files against the release's `release.manifest`, which
+   * Check the extracted files against the release's `release.manifest`, which
    * lists the exact byte size of every file in the release. A missing or
-   * size-mismatched file means the extraction is incomplete or corrupt and the
-   * game would launch with missing/partial resources (a common cause of
-   * crashes), so it fails the item.
+   * size-mismatched file usually means the extraction is incomplete or corrupt
+   * and the game may launch with missing/partial resources (a common cause of
+   * crashes).
    *
-   * The check is authoritative (exact byte sizes, no user input needed) but only
-   * runs when the manifest is present and parseable — older releases without a
-   * manifest, or an unreadable one, are skipped so this never blocks an
-   * otherwise-good install. Only files listed in the manifest are checked; extra
-   * files in the folder (including release.manifest itself) are ignored.
+   * Returns `{ ok: false, error }` describing the mismatching file(s) — the
+   * caller decides what to do (we surface it as a warning and let the user
+   * install anyway, since a release can also just ship a wrong manifest). Only
+   * runs when the manifest is present and parseable; older releases without a
+   * manifest, or an unreadable/empty one, return ok. The manifest never checks
+   * itself (it can't state its own size), and files not listed are ignored.
    */
   private async verifyAgainstReleaseManifest(
     downloadPath: string,
@@ -615,6 +632,12 @@ export class ExtractionProcessor {
 
     const mismatches: string[] = []
     for (const entry of files) {
+      // The manifest can't reliably state its own byte size (writing the size in
+      // changes the size), so some releases list release.manifest with a stale
+      // size. Never check the manifest against itself — it only ever produces a
+      // false mismatch.
+      if (entry.path.toLowerCase() === RELEASE_MANIFEST_FILENAME) continue
+
       const localPath = join(downloadPath, ...entry.path.split('/'))
       try {
         const stat = await fs.stat(localPath)

--- a/src/main/services/downloadService.ts
+++ b/src/main/services/downloadService.ts
@@ -569,6 +569,13 @@ class DownloadService extends EventEmitter implements DownloadAPI {
         return
       }
 
+      if (itemAfterExtraction.manifestWarning) {
+        console.warn(
+          `[Service ProcessQueue] ${itemAfterExtraction.releaseName} completed with a manifest mismatch - leaving in Completed state and skipping auto-install so the user can choose to install anyway.`
+        )
+        return
+      }
+
       console.log(
         `[Service ProcessQueue] Extraction successful for ${itemAfterExtraction.releaseName}. Queuing installation on ${finalTargetDeviceId}...`
       )
@@ -663,6 +670,13 @@ class DownloadService extends EventEmitter implements DownloadAPI {
       if (this.sideloadingDisabled) {
         console.log(
           `[Service ResumeQueue] Sideloading disabled - leaving ${itemAfterExtraction.releaseName} in Completed state.`
+        )
+        return
+      }
+
+      if (itemAfterExtraction.manifestWarning) {
+        console.warn(
+          `[Service ResumeQueue] ${itemAfterExtraction.releaseName} completed with a manifest mismatch - leaving in Completed state so the user can choose to install anyway.`
         )
         return
       }
@@ -1180,6 +1194,13 @@ class DownloadService extends EventEmitter implements DownloadAPI {
     if (!item) {
       console.error(`[Service installFromCompleted] Item not found: ${releaseName}`)
       throw new Error(`Item not found: ${releaseName}`)
+    }
+
+    // The user is explicitly choosing to install. If this item had a manifest
+    // mismatch warning, clear it — they've accepted the risk and it shouldn't
+    // linger on the item after installing.
+    if (item.manifestWarning) {
+      this.queueManager.updateItem(releaseName, { manifestWarning: undefined })
     }
 
     if (item.status !== 'Completed') {

--- a/src/renderer/src/components/DownloadsView.tsx
+++ b/src/renderer/src/components/DownloadsView.tsx
@@ -396,9 +396,20 @@ const DownloadsView: React.FC<DownloadsViewProps> = ({ onClose }) => {
                   </>
                 )}
                 {item.status === 'Queued' && <Text className={styles.statusText}>Queued</Text>}
-                {item.status === 'Completed' && (
-                  <Text style={{ color: tokens.colorPaletteGreenForeground1 }}>Completed</Text>
-                )}
+                {item.status === 'Completed' &&
+                  (item.manifestWarning ? (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                      <Text style={{ color: tokens.colorPaletteYellowForeground1 }}>
+                        Completed — manifest mismatch
+                      </Text>
+                      <Text size={100} style={{ color: tokens.colorPaletteYellowForeground1 }}>
+                        {item.manifestWarning}. The game may be broken; click Install to install
+                        anyway.
+                      </Text>
+                    </div>
+                  ) : (
+                    <Text style={{ color: tokens.colorPaletteGreenForeground1 }}>Completed</Text>
+                  ))}
                 {item.status === 'Cancelled' && (
                   <Text className={styles.statusText}>Cancelled</Text>
                 )}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -166,6 +166,12 @@ export interface DownloadItem {
   eta?: string
   extractProgress?: number
   size?: string
+  /**
+   * Set when the extracted files didn't match the release's release.manifest.
+   * Non-fatal: extraction still completes, but auto-install is skipped so the
+   * user can choose to install anyway. Describes the mismatching file(s).
+   */
+  manifestWarning?: string
 }
 
 export interface DownloadProgress {


### PR DESCRIPTION
…stop

Two fixes to the release.manifest check:

1. Never verify release.manifest against itself. The manifest can't state its own byte size (writing the size in changes the size), so some releases list it with a stale size — which always produced a false mismatch like "release.manifest (expected 258 B, found 323 B)".

2. A mismatch no longer hard-fails the install. A release can simply ship a wrong manifest, and the user should be able to install anyway. On a mismatch, extraction now completes with a warning (item.manifestWarning naming the mismatching file(s)) and the pipeline skips auto-install, so the item sits in Completed state. DownloadsView shows the mismatch detail and the existing Install button lets the user install anyway (which clears the warning). Older/absent manifests are unaffected.