### PR TITLE
Fix folder install failing when catalog package name is blank

### DIFF
--- a/src/main/services/download/installationProcessor.ts
+++ b/src/main/services/download/installationProcessor.ts
@@ -1,8 +1,9 @@
-import { basename, join } from 'path'
+import { basename, dirname, join } from 'path'
 import { promises as fs, existsSync } from 'fs'
 import { DownloadItem, DownloadStatus, SIGNATURE_MISMATCH_ERROR_PREFIX } from '@shared/types'
 import { QueueManager } from './queueManager'
 import adbService, { SignatureMismatchError } from '../adbService'
+import { resolveObbDirectory, ObbDirectory } from './obbResolution'
 
 export class InstallationProcessor {
   private queueManager: QueueManager
@@ -337,10 +338,12 @@ export class InstallationProcessor {
   }
 
   private async executeStandardInstall(item: DownloadItem, deviceId: string): Promise<boolean> {
-    if (!item.downloadPath || !item.packageName) {
-      console.error(
-        `[InstallProc Standard] Missing downloadPath or packageName for ${item.releaseName}`
-      )
+    // Only the download folder is truly required. The package name (used to
+    // locate and push the OBB) may be blank in the catalog for some releases —
+    // don't let a missing package name block the whole install. Install the
+    // APK first, then resolve the OBB folder separately below.
+    if (!item.downloadPath) {
+      console.error(`[InstallProc Standard] Missing downloadPath for ${item.releaseName}`)
       this.updateItemStatus(
         item.releaseName,
         'InstallError',
@@ -353,20 +356,6 @@ export class InstallationProcessor {
     try {
       const files = await fs.readdir(item.downloadPath)
       const apks = files.filter((f) => f.toLowerCase().endsWith('.apk'))
-      const obbDirName = item.packageName
-      const potentialObbPath = join(item.downloadPath, obbDirName)
-      let obbPath: string | null = null
-      if (existsSync(potentialObbPath)) {
-        const stats = await fs.stat(potentialObbPath)
-        if (stats.isDirectory()) {
-          obbPath = potentialObbPath
-          console.log(`[InstallProc Standard] Found potential OBB directory: ${obbPath}`)
-        } else {
-          console.warn(
-            `[InstallProc Standard] Found item matching package name, but it's not a directory: ${potentialObbPath}`
-          )
-        }
-      }
       if (apks.length === 0) {
         console.error(`[InstallProc Standard] No APK files found in ${item.downloadPath}`)
         this.updateItemStatus(
@@ -415,151 +404,21 @@ export class InstallationProcessor {
           return false
         }
       }
-      this.updateItemStatus(item.releaseName, 'Installing', obbPath ? 50 : 100)
-      if (obbPath) {
-        const deviceObbBasePath = '/sdcard/Android/obb'
-        const deviceObbTargetPath = `${deviceObbBasePath}/${obbDirName}`
-        console.log(
-          `[InstallProc Standard] Pushing OBB folder ${obbPath} to ${deviceObbTargetPath}...`
+      // The APK is installed. Resolve and push the OBB, if the release has one.
+      // The package name — which is also the on-disk OBB folder name and the
+      // /sdcard/Android/obb/<pkg> push target — can be blank in the catalog for
+      // some releases, so fall back to auto-detecting the OBB folder by its
+      // contents rather than failing the whole install.
+      const obb = await this.findObbDirectory(item.downloadPath, item.packageName)
+      this.updateItemStatus(item.releaseName, 'Installing', obb ? 50 : 100)
+      if (obb) {
+        const pushed = await this.pushObbFolder(
+          item.releaseName,
+          deviceId,
+          obb.obbPath,
+          obb.obbDirName
         )
-        try {
-          try {
-            await this.adbService.runShellCommand(deviceId, `mkdir -p ${deviceObbBasePath}`)
-          } catch (mkdirError) {
-            console.warn(
-              `[InstallProc Standard] Could not ensure base OBB directory exists (may already exist):`,
-              mkdirError
-            )
-          }
-
-          // Clear any existing OBB directory for this package before pushing the
-          // new files. OBB filenames can include a version number (e.g. Bonelab's
-          // main.<versionCode>.com.StressLevelZero.BONELAB.obb), so pushing an
-          // update creates a new filename alongside the old one instead of
-          // overwriting it. Without this cleanup the device accumulates stale
-          // OBBs from previous versions and bloats the app's OBB folder.
-          console.log(
-            `[InstallProc Standard] Clearing existing OBB directory ${deviceObbTargetPath} before push...`
-          )
-          try {
-            await this.adbService.runShellCommand(deviceId, `rm -rf "${deviceObbTargetPath}"`)
-          } catch (clearError) {
-            console.warn(
-              `[InstallProc Standard] Could not clear existing OBB directory (may not exist):`,
-              clearError
-            )
-          }
-
-          // Calculate total size of OBB files and track progress
-          const filesInfo = await this.getDirectoryFilesInfo(obbPath)
-          if (filesInfo.length === 0) {
-            console.log(`[InstallProc Standard] No files found in OBB directory ${obbPath}`)
-          } else {
-            const totalSize = filesInfo.reduce((sum, entry) => sum + entry.size, 0)
-            console.log(
-              `[InstallProc Standard] Found ${filesInfo.length} files in OBB folder, total size: ${totalSize} bytes`
-            )
-
-            // Create remote OBB directory
-            await this.adbService.runShellCommand(deviceId, `mkdir -p "${deviceObbTargetPath}"`)
-
-            const createdRemoteDirs = new Set<string>([deviceObbTargetPath])
-            let transferredSize = 0
-            // Push each file individually to track progress
-            for (let i = 0; i < filesInfo.length; i++) {
-              const { path: filePath, size } = filesInfo[i]
-              const relativePath = filePath.substring(obbPath.length + 1) // +1 for the slash
-              const remoteFilePath = `${deviceObbTargetPath}/${relativePath}`
-
-              // Only mkdir for directories we haven't already created
-              const remoteDir = remoteFilePath.substring(0, remoteFilePath.lastIndexOf('/'))
-              if (!createdRemoteDirs.has(remoteDir)) {
-                await this.adbService.runShellCommand(deviceId, `mkdir -p "${remoteDir}"`)
-                createdRemoteDirs.add(remoteDir)
-              }
-
-              console.log(
-                `[InstallProc Standard] Pushing file ${i + 1}/${filesInfo.length}: ${filePath} (${size} bytes)`
-              )
-
-              // Push the file — parent dir already ensured above.
-              // pushFileOrFolder returns false (rather than throwing) on a
-              // failed transfer. Ignoring it would let a missing/incomplete
-              // OBB file be reported as a successful install, which surfaces
-              // later as a game crashing on a missing resource — throw so the
-              // outer catch marks the install as failed.
-              const pushed = await this.adbService.pushFileOrFolder(
-                deviceId,
-                filePath,
-                remoteFilePath,
-                true
-              )
-              if (!pushed) {
-                throw new Error(`Failed to push OBB file ${relativePath}`)
-              }
-
-              // Update progress
-              transferredSize += size
-              const progressPercentage = Math.min(
-                Math.floor((transferredSize / totalSize) * 100),
-                100
-              )
-              this.updateItemStatus(item.releaseName, 'Installing', 50 + progressPercentage / 2)
-            }
-            console.log(`[InstallProc Standard] Successfully pushed all OBB files.`)
-
-            // Verify the OBB landed completely on the device. A push can report
-            // success at the stream level yet leave a file missing or truncated
-            // (interrupted transfer, full device storage). The game then crashes
-            // at launch on the missing/partial resource. Read the on-device file
-            // sizes back and compare them against what we pushed. This is cheap
-            // (a single shell command) so it runs on every install.
-            this.updateItemStatus(item.releaseName, 'Installing', 100)
-            const remoteSizes = await this.adbService.getRemoteFileSizes(
-              deviceId,
-              deviceObbTargetPath
-            )
-            if (remoteSizes === null) {
-              console.warn(
-                `[InstallProc Standard] Could not read back OBB file sizes from device; skipping OBB verification for ${item.releaseName}.`
-              )
-            } else {
-              const mismatches: string[] = []
-              for (const { path: verifyPath, size: expectedSize } of filesInfo) {
-                const rel = verifyPath.substring(obbPath.length + 1).replace(/\\/g, '/')
-                const actualSize = remoteSizes.get(rel)
-                if (actualSize === undefined) {
-                  mismatches.push(`${rel} (missing on device)`)
-                } else if (actualSize !== expectedSize) {
-                  mismatches.push(`${rel} (expected ${expectedSize} bytes, found ${actualSize})`)
-                }
-              }
-              if (mismatches.length > 0) {
-                const detail = mismatches.slice(0, 5).join('; ')
-                const more = mismatches.length > 5 ? ` (+${mismatches.length - 5} more)` : ''
-                throw new Error(
-                  `OBB verification failed after push: ${mismatches.length} file(s) incomplete or missing: ${detail}${more}`
-                )
-              }
-              console.log(
-                `[InstallProc Standard] Verified ${filesInfo.length} OBB file(s) on device match expected sizes.`
-              )
-            }
-          }
-
-          console.log(`[InstallProc Standard] Successfully pushed OBB folder.`)
-        } catch (obbError: unknown) {
-          const errorMsg = obbError instanceof Error ? obbError.message : String(obbError)
-          console.error(`[InstallProc Standard] Failed to push OBB folder: ${errorMsg}`)
-          this.updateItemStatus(
-            item.releaseName,
-            'InstallError',
-            100,
-            `Failed to push OBB: ${errorMsg.substring(0, 250)}`,
-            100
-          )
-          return false
-        }
+        if (!pushed) return false
       }
       console.log(
         `[InstallProc Standard] Standard installation steps completed for ${item.releaseName}.`
@@ -576,6 +435,207 @@ export class InstallationProcessor {
         'InstallError',
         100,
         `Standard install error: ${errorMsg.substring(0, 250)}`,
+        100
+      )
+      return false
+    }
+  }
+
+  /**
+   * Install a single APK the user picked directly (not a whole game folder) and,
+   * if an OBB folder sits alongside it, push that too. This mirrors the folder
+   * install, so choosing the APK inside an extracted game folder still delivers
+   * the game's OBB data instead of installing a data-less app.
+   */
+  public async installSingleApk(apkPath: string, deviceId: string): Promise<boolean> {
+    const releaseName = basename(apkPath)
+    const parentDir = dirname(apkPath)
+    console.log(`[InstallProc Standard] Installing single APK ${apkPath}...`)
+    try {
+      await this.adbService.installPackage(deviceId, apkPath, { flags: ['-r', '-g'] })
+      console.log(`[InstallProc Standard] Successfully installed ${releaseName}`)
+    } catch (installError: unknown) {
+      if (installError instanceof SignatureMismatchError) {
+        const pkgName = installError.packageName || basename(parentDir)
+        console.error(
+          `[InstallProc Standard] Signature mismatch installing ${releaseName} for package ${pkgName}.`
+        )
+        return false
+      }
+      const errorMsg = installError instanceof Error ? installError.message : String(installError)
+      console.error(`[InstallProc Standard] Failed to install ${releaseName}: ${errorMsg}`)
+      return false
+    }
+
+    const obb = await this.findObbDirectory(parentDir, undefined)
+    if (obb) {
+      console.log(
+        `[InstallProc Standard] Found OBB folder ${obb.obbPath} alongside picked APK; pushing.`
+      )
+      const pushed = await this.pushObbFolder(releaseName, deviceId, obb.obbPath, obb.obbDirName)
+      if (!pushed) return false
+    }
+    return true
+  }
+
+  /**
+   * Resolve the OBB folder for a release (see {@link resolveObbDirectory}) and
+   * log the outcome. Returns null when the release has no OBB.
+   */
+  private async findObbDirectory(
+    baseDir: string,
+    packageName: string | undefined
+  ): Promise<ObbDirectory | null> {
+    const obb = await resolveObbDirectory(baseDir, packageName, fs)
+    if (obb) {
+      console.log(`[InstallProc Standard] Resolved OBB directory: ${obb.obbPath}`)
+    }
+    return obb
+  }
+
+  /**
+   * Push an OBB folder to `/sdcard/Android/obb/<obbDirName>`, tracking progress
+   * and verifying the files landed intact. Returns false (after marking the item
+   * as errored) if any file fails to push or verify.
+   */
+  private async pushObbFolder(
+    releaseName: string,
+    deviceId: string,
+    obbPath: string,
+    obbDirName: string
+  ): Promise<boolean> {
+    const deviceObbBasePath = '/sdcard/Android/obb'
+    const deviceObbTargetPath = `${deviceObbBasePath}/${obbDirName}`
+    console.log(`[InstallProc Standard] Pushing OBB folder ${obbPath} to ${deviceObbTargetPath}...`)
+    try {
+      try {
+        await this.adbService.runShellCommand(deviceId, `mkdir -p ${deviceObbBasePath}`)
+      } catch (mkdirError) {
+        console.warn(
+          `[InstallProc Standard] Could not ensure base OBB directory exists (may already exist):`,
+          mkdirError
+        )
+      }
+
+      // Clear any existing OBB directory for this package before pushing the
+      // new files. OBB filenames can include a version number (e.g. Bonelab's
+      // main.<versionCode>.com.StressLevelZero.BONELAB.obb), so pushing an
+      // update creates a new filename alongside the old one instead of
+      // overwriting it. Without this cleanup the device accumulates stale
+      // OBBs from previous versions and bloats the app's OBB folder.
+      console.log(
+        `[InstallProc Standard] Clearing existing OBB directory ${deviceObbTargetPath} before push...`
+      )
+      try {
+        await this.adbService.runShellCommand(deviceId, `rm -rf "${deviceObbTargetPath}"`)
+      } catch (clearError) {
+        console.warn(
+          `[InstallProc Standard] Could not clear existing OBB directory (may not exist):`,
+          clearError
+        )
+      }
+
+      // Calculate total size of OBB files and track progress
+      const filesInfo = await this.getDirectoryFilesInfo(obbPath)
+      if (filesInfo.length === 0) {
+        console.log(`[InstallProc Standard] No files found in OBB directory ${obbPath}`)
+      } else {
+        const totalSize = filesInfo.reduce((sum, entry) => sum + entry.size, 0)
+        console.log(
+          `[InstallProc Standard] Found ${filesInfo.length} files in OBB folder, total size: ${totalSize} bytes`
+        )
+
+        // Create remote OBB directory
+        await this.adbService.runShellCommand(deviceId, `mkdir -p "${deviceObbTargetPath}"`)
+
+        const createdRemoteDirs = new Set<string>([deviceObbTargetPath])
+        let transferredSize = 0
+        // Push each file individually to track progress
+        for (let i = 0; i < filesInfo.length; i++) {
+          const { path: filePath, size } = filesInfo[i]
+          const relativePath = filePath.substring(obbPath.length + 1) // +1 for the slash
+          const remoteFilePath = `${deviceObbTargetPath}/${relativePath}`
+
+          // Only mkdir for directories we haven't already created
+          const remoteDir = remoteFilePath.substring(0, remoteFilePath.lastIndexOf('/'))
+          if (!createdRemoteDirs.has(remoteDir)) {
+            await this.adbService.runShellCommand(deviceId, `mkdir -p "${remoteDir}"`)
+            createdRemoteDirs.add(remoteDir)
+          }
+
+          console.log(
+            `[InstallProc Standard] Pushing file ${i + 1}/${filesInfo.length}: ${filePath} (${size} bytes)`
+          )
+
+          // Push the file — parent dir already ensured above.
+          // pushFileOrFolder returns false (rather than throwing) on a
+          // failed transfer. Ignoring it would let a missing/incomplete
+          // OBB file be reported as a successful install, which surfaces
+          // later as a game crashing on a missing resource — throw so the
+          // outer catch marks the install as failed.
+          const pushed = await this.adbService.pushFileOrFolder(
+            deviceId,
+            filePath,
+            remoteFilePath,
+            true
+          )
+          if (!pushed) {
+            throw new Error(`Failed to push OBB file ${relativePath}`)
+          }
+
+          // Update progress
+          transferredSize += size
+          const progressPercentage = Math.min(Math.floor((transferredSize / totalSize) * 100), 100)
+          this.updateItemStatus(releaseName, 'Installing', 50 + progressPercentage / 2)
+        }
+        console.log(`[InstallProc Standard] Successfully pushed all OBB files.`)
+
+        // Verify the OBB landed completely on the device. A push can report
+        // success at the stream level yet leave a file missing or truncated
+        // (interrupted transfer, full device storage). The game then crashes
+        // at launch on the missing/partial resource. Read the on-device file
+        // sizes back and compare them against what we pushed. This is cheap
+        // (a single shell command) so it runs on every install.
+        this.updateItemStatus(releaseName, 'Installing', 100)
+        const remoteSizes = await this.adbService.getRemoteFileSizes(deviceId, deviceObbTargetPath)
+        if (remoteSizes === null) {
+          console.warn(
+            `[InstallProc Standard] Could not read back OBB file sizes from device; skipping OBB verification for ${releaseName}.`
+          )
+        } else {
+          const mismatches: string[] = []
+          for (const { path: verifyPath, size: expectedSize } of filesInfo) {
+            const rel = verifyPath.substring(obbPath.length + 1).replace(/\\/g, '/')
+            const actualSize = remoteSizes.get(rel)
+            if (actualSize === undefined) {
+              mismatches.push(`${rel} (missing on device)`)
+            } else if (actualSize !== expectedSize) {
+              mismatches.push(`${rel} (expected ${expectedSize} bytes, found ${actualSize})`)
+            }
+          }
+          if (mismatches.length > 0) {
+            const detail = mismatches.slice(0, 5).join('; ')
+            const more = mismatches.length > 5 ? ` (+${mismatches.length - 5} more)` : ''
+            throw new Error(
+              `OBB verification failed after push: ${mismatches.length} file(s) incomplete or missing: ${detail}${more}`
+            )
+          }
+          console.log(
+            `[InstallProc Standard] Verified ${filesInfo.length} OBB file(s) on device match expected sizes.`
+          )
+        }
+      }
+
+      console.log(`[InstallProc Standard] Successfully pushed OBB folder.`)
+      return true
+    } catch (obbError: unknown) {
+      const errorMsg = obbError instanceof Error ? obbError.message : String(obbError)
+      console.error(`[InstallProc Standard] Failed to push OBB folder: ${errorMsg}`)
+      this.updateItemStatus(
+        releaseName,
+        'InstallError',
+        100,
+        `Failed to push OBB: ${errorMsg.substring(0, 250)}`,
         100
       )
       return false

--- a/src/main/services/download/obbResolution.test.mjs
+++ b/src/main/services/download/obbResolution.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolveObbDirectory } from './obbResolution.ts'
+
+/**
+ * Build a fake ObbFileSystem from a plain description of a directory tree.
+ * `tree` maps an absolute dir path to either an array of `{ name, dir }` entries
+ * (for the withFileTypes listing) or, for leaf OBB dirs, an array of file names.
+ */
+function makeFs(tree) {
+  return {
+    async readdir(path, options) {
+      const entry = tree[path]
+      if (entry === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      if (options && options.withFileTypes) {
+        return entry.map((e) => ({ name: e.name, isDirectory: () => !!e.dir }))
+      }
+      // Plain listing: return file names (entries described as strings).
+      return entry.map((e) => (typeof e === 'string' ? e : e.name))
+    }
+  }
+}
+
+test('resolves the OBB folder by explicit package name', async () => {
+  const fs = makeFs({
+    '/dl': [
+      { name: 'game.apk', dir: false },
+      { name: 'com.sanzaru.AW2', dir: true }
+    ]
+  })
+  const obb = await resolveObbDirectory('/dl', 'com.sanzaru.AW2', fs)
+  assert.deepEqual(obb, {
+    obbPath: '/dl/com.sanzaru.AW2',
+    obbDirName: 'com.sanzaru.AW2'
+  })
+})
+
+test('auto-detects the OBB folder when the package name is blank', async () => {
+  const fs = makeFs({
+    '/dl': [
+      { name: 'game.apk', dir: false },
+      { name: 'com.sanzaru.AW2', dir: true }
+    ],
+    '/dl/com.sanzaru.AW2': ['main.5513.com.sanzaru.AW2.obb']
+  })
+  const obb = await resolveObbDirectory('/dl', '', fs)
+  assert.deepEqual(obb, {
+    obbPath: '/dl/com.sanzaru.AW2',
+    obbDirName: 'com.sanzaru.AW2'
+  })
+})
+
+test('auto-detects even when the package name is undefined (single-APK case)', async () => {
+  const fs = makeFs({
+    '/dl': [{ name: 'com.foo.Bar', dir: true }],
+    '/dl/com.foo.Bar': ['patch.1.com.foo.Bar.OBB'] // uppercase extension
+  })
+  const obb = await resolveObbDirectory('/dl', undefined, fs)
+  assert.deepEqual(obb, { obbPath: '/dl/com.foo.Bar', obbDirName: 'com.foo.Bar' })
+})
+
+test('returns null for an APK-only release with no OBB folder', async () => {
+  const fs = makeFs({
+    '/dl': [{ name: 'game.apk', dir: false }]
+  })
+  const obb = await resolveObbDirectory('/dl', '', fs)
+  assert.equal(obb, null)
+})
+
+test('ignores a package-style folder that holds no .obb files', async () => {
+  const fs = makeFs({
+    '/dl': [{ name: 'com.foo.Bar', dir: true }],
+    '/dl/com.foo.Bar': ['readme.txt']
+  })
+  const obb = await resolveObbDirectory('/dl', '', fs)
+  assert.equal(obb, null)
+})
+
+test('does not treat a non-package-style folder as an OBB folder during auto-detect', async () => {
+  const fs = makeFs({
+    '/dl': [{ name: 'extras', dir: true }],
+    '/dl/extras': ['something.obb']
+  })
+  // Auto-detect only considers dotted (package-style) folder names.
+  const obb = await resolveObbDirectory('/dl', '', fs)
+  assert.equal(obb, null)
+})
+
+test('falls back to auto-detect when the explicit package name has no matching folder', async () => {
+  const fs = makeFs({
+    '/dl': [{ name: 'com.actual.Pkg', dir: true }],
+    '/dl/com.actual.Pkg': ['main.1.com.actual.Pkg.obb']
+  })
+  const obb = await resolveObbDirectory('/dl', 'com.stale.Wrong', fs)
+  assert.deepEqual(obb, { obbPath: '/dl/com.actual.Pkg', obbDirName: 'com.actual.Pkg' })
+})
+
+test('returns null when the base directory cannot be read', async () => {
+  const fs = {
+    async readdir() {
+      throw Object.assign(new Error('boom'), { code: 'EACCES' })
+    }
+  }
+  const obb = await resolveObbDirectory('/nope', 'com.x.y', fs)
+  assert.equal(obb, null)
+})

--- a/src/main/services/download/obbResolution.ts
+++ b/src/main/services/download/obbResolution.ts
@@ -1,0 +1,71 @@
+import { join } from 'path'
+
+export interface ObbDirectory {
+  /** Absolute path to the OBB folder on disk. */
+  obbPath: string
+  /** Folder name, which is also the package and the /sdcard/Android/obb/<name> target. */
+  obbDirName: string
+}
+
+/** Directory entry shape we rely on (a subset of Node's Dirent). */
+export interface DirEntryLike {
+  name: string
+  isDirectory(): boolean
+}
+
+/** Minimal filesystem surface needed to resolve an OBB folder — injectable for tests. */
+export interface ObbFileSystem {
+  readdir(path: string, options: { withFileTypes: true }): Promise<DirEntryLike[]>
+  readdir(path: string): Promise<string[]>
+}
+
+/**
+ * Locate the OBB folder for a release inside `baseDir`.
+ *
+ * The OBB folder is named after the app's package (e.g. `com.sanzaru.AW2`) and
+ * is pushed to `/sdcard/Android/obb/<package>`. Resolution order, by confidence:
+ *   1. An explicit package name (from the catalog) that matches a directory on disk.
+ *   2. Auto-detection: a package-style subfolder (name contains a dot) that
+ *      actually holds `.obb` files. This covers releases whose catalog package
+ *      name is blank — the case that otherwise blocks the whole install.
+ *
+ * Returns null when the release has no OBB (e.g. an APK-only game), in which
+ * case an APK-only install is still a success.
+ */
+export async function resolveObbDirectory(
+  baseDir: string,
+  packageName: string | undefined,
+  fs: ObbFileSystem
+): Promise<ObbDirectory | null> {
+  let dirEntries: DirEntryLike[]
+  try {
+    const entries = await fs.readdir(baseDir, { withFileTypes: true })
+    dirEntries = entries.filter((e) => e.isDirectory())
+  } catch {
+    return null
+  }
+
+  // 1. Explicit package name that matches a directory on disk.
+  if (packageName) {
+    const match = dirEntries.find((e) => e.name === packageName)
+    if (match) {
+      return { obbPath: join(baseDir, packageName), obbDirName: packageName }
+    }
+  }
+
+  // 2. Auto-detect a package-style folder that actually contains .obb files.
+  for (const entry of dirEntries) {
+    if (!entry.name.includes('.')) continue
+    const dirPath = join(baseDir, entry.name)
+    try {
+      const inner = await fs.readdir(dirPath)
+      if (inner.some((f) => f.toLowerCase().endsWith('.obb'))) {
+        return { obbPath: dirPath, obbDirName: entry.name }
+      }
+    } catch {
+      /* ignore unreadable subdirs */
+    }
+  }
+
+  return null
+}

--- a/src/main/services/downloadService.ts
+++ b/src/main/services/downloadService.ts
@@ -1381,11 +1381,12 @@ class DownloadService extends EventEmitter implements DownloadAPI {
       const stats = await fs.stat(filePath)
 
       if (stats.isFile() && filePath.toLowerCase().endsWith('.apk')) {
-        // Single APK file installation
+        // Single APK file installation. Route through the installation processor
+        // so that if an OBB folder sits alongside the chosen APK (i.e. the user
+        // picked/dropped the APK from inside an extracted game folder) it gets
+        // pushed too, instead of installing a data-less app.
         console.log(`[Service installManualFile] Installing single APK: ${filePath}`)
-        const success = await this.adbService.installPackage(deviceId, filePath, {
-          flags: ['-r', '-g']
-        })
+        const success = await this.installationProcessor.installSingleApk(filePath, deviceId)
         if (success) {
           console.log(`[Service installManualFile] Successfully installed APK: ${filePath}`)
           this.emit('installation:success', deviceId)


### PR DESCRIPTION
Standard install (folder with APK + OBB) aborted with "Missing downloadPath or packageName" before it ever looked for the APK whenever a release's catalog packageName was empty (e.g. Asgard's Wrath 2). The package name is only needed to locate/push the OBB, not to install the APK, so a blank name should not block the whole install.

- executeStandardInstall now requires only downloadPath. It installs the APK(s) first, then resolves the OBB folder separately.
- OBB resolution is extracted into a dependency-injected helper (resolveObbDirectory) that falls back to auto-detecting the OBB folder by its contents (a package-style subfolder holding .obb files) when the package name is blank. Covers the case where aapt isn't available too.
- Single-APK manual install (including drag-and-drop of an APK) now routes through installSingleApk, which installs the APK and pushes a sibling OBB folder if one sits next to it, instead of installing a data-less app.
- Add unit tests for resolveObbDirectory.
