### PR TITLE
Follow-ups to game-details enrichment: CI, versioned UA, privacy gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+# Fast, cross-platform-agnostic checks for every PR and every push to main:
+# type safety and the unit-test suites. These do NOT build or launch Electron,
+# so they run in ~a minute and catch the regressions a merge would otherwise
+# hide (the game-details work merged with no CI watching typecheck at all).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel superseded runs on the same ref so a rapid push sequence doesn't queue.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Typecheck & tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Node 22 strips TypeScript types natively, which the *.test.mjs
+          # suites rely on to import their .ts subjects directly.
+          node-version: '22.x'
+          cache: 'npm'
+
+      # --ignore-scripts skips Electron's binary download and native rebuilds:
+      # none of the checks below launch Electron, so we don't pay for it.
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
+
+      - name: Typecheck (main / node)
+        run: npm run typecheck:node
+
+      - name: Typecheck (renderer / web)
+        run: npm run typecheck:web
+
+      - name: Unit tests (vitest)
+        run: npm test
+
+      - name: Unit tests (node --test)
+        run: npm run test:node
+
+  lint:
+    name: Lint (informational)
+    runs-on: ubuntu-latest
+    # Non-blocking for now: the repo carries pre-existing prettier/eslint debt,
+    # so surface it without failing the merge. Flip continue-on-error off once
+    # `npm run lint` is clean.
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
+
+      - name: Lint
+        run: npm run lint

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -360,7 +360,8 @@ app.whenReady().then(async () => {
   // nothing is locked. Runs before createWindow so no files are in use yet.
   const userData = app.getPath('userData')
   const gameDescriptionService = createGameDescriptionService(
-    join(userData, 'vrp-data', 'game-description-cache-v1.json')
+    join(userData, 'vrp-data', 'game-description-cache-v1.json'),
+    app.getVersion()
   )
   const resetFlag = join(userData, 'pending-data-reset')
   if (existsSync(resetFlag)) {

--- a/src/main/services/gameDescription/gameDescriptionService.test.ts
+++ b/src/main/services/gameDescription/gameDescriptionService.test.ts
@@ -88,6 +88,49 @@ describe('GameDescriptionService', () => {
     expect(provider.lookup).not.toHaveBeenCalled()
   })
 
+  it('skips the network lookup when allowNetwork is false (Disable All Extras)', async () => {
+    const cache = createCache()
+    const provider = { lookup: vi.fn() }
+    const service = new GameDescriptionService({
+      cache,
+      provider,
+      // No qualifying library image → would normally fall through to Wikipedia.
+      probeImage: vi.fn(async () => null)
+    })
+
+    await expect(
+      service.getDescription({ ...sourceQualifiedGame, allowNetwork: false })
+    ).resolves.toMatchObject({ status: 'not-found' })
+
+    // Never reached the network, and did not negative-cache the skip.
+    expect(provider.lookup).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('still performs the lookup when allowNetwork is unset (default allowed)', async () => {
+    const cache = createCache()
+    const provider = {
+      lookup: vi.fn(async () => ({
+        status: 'found' as const,
+        text: 'A virtual reality game.',
+        source: { label: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Test' },
+        language: 'en' as const,
+        fetchedAt: 3
+      }))
+    }
+    const service = new GameDescriptionService({
+      cache,
+      provider,
+      probeImage: vi.fn(async () => null)
+    })
+
+    await expect(service.getDescription(sourceQualifiedGame)).resolves.toMatchObject({
+      status: 'found',
+      source: { label: 'Wikipedia' }
+    })
+    expect(provider.lookup).toHaveBeenCalledTimes(1)
+  })
+
   it('does not negative-cache temporary provider failures', async () => {
     const cache = createCache()
     const provider = { lookup: vi.fn().mockRejectedValue(new Error('offline')) }

--- a/src/main/services/gameDescription/gameDescriptionService.ts
+++ b/src/main/services/gameDescription/gameDescriptionService.ts
@@ -70,6 +70,13 @@ export class GameDescriptionService {
     const cached = await this.dependencies.cache.get(key)
     if (cached) return cached
 
+    // Respect the user's "Disable All Extras" choice: serve local library data
+    // and any prior cached result, but never initiate a network lookup. Not
+    // cached, so a later request with extras re-enabled still tries.
+    if (request.allowNetwork === false) {
+      return { status: 'not-found', language: request.language, fetchedAt: Date.now() }
+    }
+
     const existing = this.inFlight.get(key)
     if (existing) return existing
 
@@ -126,9 +133,12 @@ export const probeLocalImage = async (path: string): Promise<ImageDimensions | n
   }
 }
 
-export const createGameDescriptionService = (cachePath: string): GameDescriptionService =>
+export const createGameDescriptionService = (
+  cachePath: string,
+  appVersion?: string
+): GameDescriptionService =>
   new GameDescriptionService({
     cache: new DescriptionCache(cachePath),
-    provider: new WikipediaDescriptionProvider(),
+    provider: new WikipediaDescriptionProvider(undefined, appVersion),
     probeImage: probeLocalImage
   })

--- a/src/main/services/gameDescription/wikipediaProvider.ts
+++ b/src/main/services/gameDescription/wikipediaProvider.ts
@@ -42,7 +42,18 @@ const pagesFrom = (response: WikipediaResponse): WikipediaPage[] => {
 }
 
 export class WikipediaDescriptionProvider {
-  constructor(private readonly get: WikipediaGet = axios.get as WikipediaGet) {}
+  private readonly userAgent: string
+
+  constructor(
+    private readonly get: WikipediaGet = axios.get as WikipediaGet,
+    appVersion?: string
+  ) {
+    // Wikipedia's API policy asks for a descriptive, contactable User-Agent.
+    // The version is injected by the caller (from app.getVersion()) so it can't
+    // drift out of sync with the app the way a hardcoded string does; the pure
+    // provider stays free of any Electron import so it remains unit-testable.
+    this.userAgent = `VR-CyberDeck/${appVersion ?? 'dev'} (https://github.com/DeliciousMeatPop/VRCD)`
+  }
 
   async lookup(
     gameName: string,
@@ -63,7 +74,7 @@ export class WikipediaDescriptionProvider {
         formatversion: '2'
       },
       headers: {
-        'User-Agent': 'VR-CyberDeck/1.6 (https://github.com/DeliciousMeatPop/VRCD)'
+        'User-Agent': this.userAgent
       }
     })
 

--- a/src/renderer/src/context/GamesProvider.tsx
+++ b/src/renderer/src/context/GamesProvider.tsx
@@ -11,6 +11,18 @@ import { GamesContext } from './GamesContext'
 import { useAdb } from '../hooks/useAdb'
 import { useDependency } from '../hooks/useDependency'
 import { toGameDescriptionRequest } from '../utils/gameDescription'
+import { DISABLE_ALL_EXTRAS_KEY } from '../hooks/useExtrasSettings'
+
+// True when the user has enabled "Disable All Extras". Read directly from
+// localStorage (rather than the hook) so the non-React getDescription callback
+// stays simple; a read failure defaults to extras-enabled.
+const areExtrasDisabled = (): boolean => {
+  try {
+    return localStorage.getItem(DISABLE_ALL_EXTRAS_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
 
 interface GamesProviderProps {
   children: ReactNode
@@ -372,7 +384,10 @@ export const GamesProvider: React.FC<GamesProviderProps> = ({ children }) => {
 
   const getDescription = useCallback(
     async (request: GameDescriptionRequest): Promise<GameDescriptionResult> => {
-      const result = await window.api.games.getDescription(request)
+      const result = await window.api.games.getDescription({
+        ...request,
+        allowNetwork: !areExtrasDisabled()
+      })
       if (result.status !== 'error') {
         setDescriptionSnapshot((current) => ({ ...current, [request.key]: result }))
       }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -141,6 +141,13 @@ export interface GameDescriptionRequest {
   libraryDescriptionSourceLabel?: string
   libraryDescriptionSourceUrl?: string
   libraryDescriptionLanguage?: GameDescriptionLanguage
+  /**
+   * Whether an external (Wikipedia) lookup is permitted for this request when
+   * no local library description qualifies. Defaults to allowed; the renderer
+   * sets it to false when the user has enabled "Disable All Extras", so details
+   * still show local metadata but never reach out to the network.
+   */
+  allowNetwork?: boolean
 }
 
 export type GameDescriptionSnapshot = Record<string, GameDescriptionResult>


### PR DESCRIPTION
Post-merge mitigations for the game-description feature (#45).

1. CI (.github/workflows/ci.yml): the feature merged with no automated typecheck/test gate. Add a fast Node 22 workflow running typecheck:node, typecheck:web, vitest and node --test on every PR and push to main (Node 22 so the *.test.mjs suites can strip TS types to import their .ts subjects). Lint runs informational-only for now, as the repo carries pre-existing prettier debt. Typecheck is currently green on main; this keeps it that way.

2. Versioned Wikipedia User-Agent: the provider hardcoded "VR-CyberDeck/1.6" (app is 1.7.6). Inject app.getVersion() through createGameDescriptionService so the UA can't drift; the provider takes it as a constructor arg and stays free of any Electron import, so it remains unit-testable.

3. Privacy gate: the details view reached out to Wikipedia even with "Disable All Extras" on. Thread an allowNetwork flag on the description request (default allowed); the renderer sets it false when extras are disabled, and the service then serves local library + cached data but never initiates a network lookup (and does not negative-cache the skip, so it retries once extras are re-enabled).

Adds unit tests for the gate; typecheck (node+web) and both test suites pass.
