### PR TITLE
Fix CI install + clear the 39 ESLint errors, make lint blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # --ignore-scripts skips Electron's binary download and native rebuilds:
       # none of the checks below launch Electron, so we don't pay for it.
       - name: Install dependencies
-        run: npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Typecheck (main / node)
         run: npm run typecheck:node
@@ -49,12 +49,9 @@ jobs:
         run: npm run test:node
 
   lint:
-    name: Lint (informational)
+    name: Lint
     runs-on: ubuntu-latest
-    # Non-blocking for now: the repo carries pre-existing prettier/eslint debt,
-    # so surface it without failing the merge. Flip continue-on-error off once
-    # `npm run lint` is clean.
-    continue-on-error: true
+    # Blocking: `npm run lint` is clean of errors (warnings don't fail eslint).
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,7 +63,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm install --legacy-peer-deps --ignore-scripts --no-audit --no-fund
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Lint
         run: npm run lint

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,5 +27,18 @@ export default tseslint.config(
       ...eslintPluginReactRefresh.configs.vite.rules
     }
   },
+  {
+    // Node/CommonJS build & release scripts (build/*.cjs, .github/scripts/*.js)
+    // and the plain-JS *.test.mjs suites are hand-written JavaScript, not
+    // TypeScript. The typed rules from the recommended TS preset don't apply
+    // there — require() is correct in CJS, and TS return-type annotations
+    // aren't even valid syntax in a .mjs/.js file.
+    files: ['**/*.{js,cjs,mjs}'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-explicit-any': 'off'
+    }
+  },
   eslintConfigPrettier
 )

--- a/src/renderer/src/components/AdbShellDialog.tsx
+++ b/src/renderer/src/components/AdbShellDialog.tsx
@@ -805,7 +805,7 @@ export function AdbShellDialog({
                 onClick={() => inputRef.current?.focus()}
               >
                 {history.length === 0 && (
-                  <span style={S.emptyHint}>// type a shell command and press Enter</span>
+                  <span style={S.emptyHint}>{'// type a shell command and press Enter'}</span>
                 )}
 
                 {history.map((entry, i) => (

--- a/src/renderer/src/components/AdbShortcuts.tsx
+++ b/src/renderer/src/components/AdbShortcuts.tsx
@@ -533,7 +533,7 @@ const AdbShortcuts: React.FC<AdbShortcutsProps> = ({ onRun, disabled }) => {
               letterSpacing: '0.14em'
             }}
           >
-            // QUICK COMMANDS
+            {'// QUICK COMMANDS'}
           </span>
           <span
             style={{

--- a/src/renderer/src/components/CreditsDialog.tsx
+++ b/src/renderer/src/components/CreditsDialog.tsx
@@ -57,7 +57,7 @@ const CreditsDialog: React.FC<CreditsDialogProps> = ({ open, onClose, variant = 
             {CREW.map((member, i) => (
               <div key={i} className="credits-crew-entry">
                 <span className="credits-name">{member.name}</span>
-                {member.desc && <span className="credits-desc">// {member.desc}</span>}
+                {member.desc && <span className="credits-desc">{'// '}{member.desc}</span>}
               </div>
             ))}
           </div>

--- a/src/renderer/src/components/DeviceList.tsx
+++ b/src/renderer/src/components/DeviceList.tsx
@@ -336,7 +336,7 @@ const TargetCard: React.FC<TargetCardProps> = ({
   const isOffline = device.type === 'offline'
   const isUnauth = device.type === 'unauthorized'
   const isWifi = isWifiBook || (hasBook && isTcp && isConnectable)
-  const name = device.friendlyModelName || (device as any).model || device.id
+  const name = device.friendlyModelName || device.model || device.id
   const statusBadgeColor = isConnected
     ? 'var(--vrcd-neon)'
     : connectionError
@@ -459,7 +459,7 @@ const TargetCard: React.FC<TargetCardProps> = ({
             </span>
 
             {/* IP */}
-            {(device as any).ipAddress && (
+            {device.ipAddress && (
               <span
                 style={{
                   ...S,
@@ -468,34 +468,34 @@ const TargetCard: React.FC<TargetCardProps> = ({
                   letterSpacing: '0.06em'
                 }}
               >
-                IP: {(device as any).ipAddress}
+                IP: {device.ipAddress}
               </span>
             )}
 
             {/* Battery */}
-            {(device as any).batteryLevel != null && (
+            {device.batteryLevel != null && (
               <span style={{ ...S, fontSize: '10px', color: 'rgba(var(--vrcd-neon-raw),0.5)' }}>
-                ⚡ {(device as any).batteryLevel}%
+                ⚡ {device.batteryLevel}%
               </span>
             )}
 
             {/* Storage */}
-            {(device as any).storageFree && (
+            {device.storageFree && (
               <span style={{ ...S, fontSize: '10px', color: 'rgba(var(--vrcd-neon-raw),0.5)' }}>
-                💾 {(device as any).storageFree} free
+                💾 {device.storageFree} free
               </span>
             )}
 
             {/* Ping / signal */}
             {isWifi && (
               <span>
-                {(device as any).pingStatus === 'reachable' && (
-                  <SignalBars ms={(device as any).pingResponseTime ?? null} />
+                {device.pingStatus === 'reachable' && (
+                  <SignalBars ms={device.pingResponseTime ?? null} />
                 )}
-                {(device as any).pingStatus === 'unreachable' && (
+                {device.pingStatus === 'unreachable' && (
                   <span style={{ ...S, fontSize: '10px', color: '#ff4444' }}>OFFLINE</span>
                 )}
-                {(device as any).pingStatus === 'checking' && (
+                {device.pingStatus === 'checking' && (
                   <span style={{ ...S, fontSize: '10px', color: 'rgba(var(--vrcd-neon-raw),0.4)' }}>
                     PINGING...
                   </span>
@@ -504,7 +504,7 @@ const TargetCard: React.FC<TargetCardProps> = ({
             )}
 
             {/* Non-Quest warning */}
-            {isConnectable && !(device as any).isQuestDevice && !isWifi && (
+            {isConnectable && !device.isQuestDevice && !isWifi && (
               <span style={{ ...S, fontSize: '10px', color: '#f5a623' }}>⚠ UNKNOWN DEVICE</span>
             )}
           </div>
@@ -596,7 +596,7 @@ const TargetCard: React.FC<TargetCardProps> = ({
             <button
               className="breach-btn breach-btn-primary"
               onClick={onConnect}
-              disabled={(device as any).pingStatus === 'unreachable'}
+              disabled={device.pingStatus === 'unreachable'}
               style={{ fontSize: '10px', padding: '5px 12px' }}
             >
               ▶ BREACH
@@ -618,7 +618,7 @@ const TargetCard: React.FC<TargetCardProps> = ({
             >
               ▶ BREACH
             </button>
-            {(device as any).ipAddress && !isTcp && !isAlreadyBookmarked && (
+            {device.ipAddress && !isTcp && !isAlreadyBookmarked && (
               <button
                 className="breach-btn"
                 onClick={onBookmark}
@@ -805,7 +805,7 @@ const DeviceList: React.FC<DeviceListProps> = ({ onSkip, onConnected }) => {
   useEffect(() => {
     if (isConnected || isLoading || hasAutoConnected.current) return
     const q = devices.find(
-      (d) => (d as any).isQuestDevice && (d.type === 'device' || d.type === 'emulator')
+      (d) => d.isQuestDevice && (d.type === 'device' || d.type === 'emulator')
     )
     if (!q) return
     hasAutoConnected.current = true
@@ -819,7 +819,7 @@ const DeviceList: React.FC<DeviceListProps> = ({ onSkip, onConnected }) => {
         .filter((d) => isWiFiBookmark(d) || hasBookmarkData(d))
         .map((d) =>
           isWiFiBookmark(d)
-            ? (d as any).ipAddress
+            ? d.ipAddress
             : hasBookmarkData(d)
               ? d.bookmarkData.ipAddress
               : null
@@ -909,9 +909,9 @@ const DeviceList: React.FC<DeviceListProps> = ({ onSkip, onConnected }) => {
 
   const handleBookmark = useCallback(
     async (device: ExtendedDeviceInfo): Promise<void> => {
-      const ip = (device as any).ipAddress
+      const ip = device.ipAddress
       if (!ip) return
-      const name = device.friendlyModelName || (device as any).model || device.id
+      const name = device.friendlyModelName || device.model || device.id
       await window.api.wifiBookmarks.add(`${name} (${ip})`, ip, 5555)
       refreshDevices()
     },
@@ -948,7 +948,7 @@ const DeviceList: React.FC<DeviceListProps> = ({ onSkip, onConnected }) => {
   const breachDeviceName = breachDevice
     ? (
         breachDevice.friendlyModelName ||
-        (breachDevice as any).model ||
+        breachDevice.model ||
         breachDevice.id
       ).toUpperCase()
     : tcpIpAddress || '...'
@@ -1170,8 +1170,8 @@ const DeviceList: React.FC<DeviceListProps> = ({ onSkip, onConnected }) => {
                     onDeleteBookmark={() => handleDeleteBookmark(device)}
                     onOpenShell={() => setShellDialogDeviceId(device.id)}
                     isAlreadyBookmarked={
-                      !!(device as any).ipAddress &&
-                      bookmarkedIps.includes((device as any).ipAddress)
+                      !!device.ipAddress &&
+                      bookmarkedIps.includes(device.ipAddress)
                     }
                   />
                 )

--- a/src/renderer/src/components/ErrorBoundary.tsx
+++ b/src/renderer/src/components/ErrorBoundary.tsx
@@ -45,7 +45,7 @@ export class ErrorBoundary extends React.Component<{ children: React.ReactNode }
         }}
       >
         <div style={{ fontSize: '32px', color: 'var(--vrcd-neon)', letterSpacing: '0.1em' }}>
-          // SYSTEM FAULT
+          {'// SYSTEM FAULT'}
         </div>
         <div
           style={{

--- a/src/renderer/src/components/GameDetailsDialog.tsx
+++ b/src/renderer/src/components/GameDetailsDialog.tsx
@@ -856,7 +856,7 @@ const GameDetailsDialog: React.FC<GameDetailsDialogProps> = ({
                 marginBottom: 6
               }}
             >
-              // NOTE
+              {'// NOTE'}
             </div>
             {loadingNote ? (
               <Spinner size="tiny" label="Loading..." />

--- a/src/renderer/src/components/GamesView.tsx
+++ b/src/renderer/src/components/GamesView.tsx
@@ -903,7 +903,7 @@ const GamesView: React.FC<GamesViewProps> = ({ onBackToDevices, onTransfers, onS
               cb = b[i]
             if (ca === cb) continue
             // priority: _ (0) → 0-9 (1) → everything else (2)
-            const p = (c: string) => (c === '_' ? 0 : c >= '0' && c <= '9' ? 1 : 2)
+            const p = (c: string): number => (c === '_' ? 0 : c >= '0' && c <= '9' ? 1 : 2)
             const pa = p(ca),
               pb = p(cb)
             if (pa !== pb) return pa - pb

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -644,7 +644,7 @@ const ExtraSystemsSettings: React.FC = () => {
     })
   }
 
-  const neonOptionBtn = (active: boolean) => ({
+  const neonOptionBtn = (active: boolean): React.CSSProperties => ({
     background: active ? 'rgba(var(--vrcd-neon-raw),0.12)' : 'transparent',
     border: `1px solid ${active ? 'var(--vrcd-neon)' : 'rgba(var(--vrcd-neon-raw),0.25)'}`,
     color: active ? 'var(--vrcd-neon)' : 'rgba(var(--vrcd-neon-raw),0.5)',
@@ -1002,7 +1002,7 @@ const ExtraSystemsSettings: React.FC = () => {
               marginBottom: '4px'
             }}
           >
-            // LOADED FILES
+            {'// LOADED FILES'}
           </div>
           {SOUND_NAMES.map((name) => {
             const isLoaded = !!soundLoaded[name]
@@ -2230,7 +2230,9 @@ const Settings: React.FC = () => {
                       setHideAdultContentLocal(d.checked)
                       try {
                         localStorage.setItem('vrcyberdeck:hideAdult', String(d.checked))
-                      } catch {}
+                      } catch {
+                        /* ignore storage errors */
+                      }
                     }}
                   />
                 </div>


### PR DESCRIPTION
The CI workflow was red on two counts:

* typecheck:web failed with "has no exported member 'fireEvent'/'screen'/ 'within'" from @testing-library/react. The install used --legacy-peer-deps (copied from mac-build.yml), which skips peer deps, so @testing-library/dom — where those symbols actually live — was never installed. Drop the flag from the CI install; a plain install pulls the peer and typecheck passes.

* The lint job reported 39 real ESLint errors. Fix them all:
  - DeviceList.tsx: 21 `(device as any).x` casts were unnecessary — ExtendedDeviceInfo is DeviceInfo | DeviceWithBookmark and the latter extends the former, so every accessed field already exists on the union. Drop the casts.
  - Six react/jsx-no-comment-textnodes: decorative "// LABEL" UI text was parsed as JSX comments; wrap each in a string expression so the rendered text is unchanged.
  - Two explicit-function-return-type (GamesView, Settings) and one no-empty (Settings) get an explicit return type / a commented catch body.
  - eslint.config.mjs: the recommended TS ruleset was being applied to plain JS (build/*.cjs, .github/scripts/*.js, *.test.mjs) where require() is correct and TS return-type annotations aren't valid syntax. Add a JS-family override turning those typed rules off.

With lint now clean of errors, drop continue-on-error so it gates merges.

Verified locally: lint 0 errors, typecheck node+web pass, vitest 27, node --test 51/52 (1 pre-existing skip).