### PR TITLE
Add SOCKS5 + authenticated download proxies; fix merged #52 CI breakage

### DIFF
--- a/src/main/services/download/downloadProxy.test.mjs
+++ b/src/main/services/download/downloadProxy.test.mjs
@@ -24,6 +24,8 @@ test('builds a game-download environment that forces custom proxy routing', () =
     http_proxy: 'https://[2001:db8::7]:8443',
     HTTPS_PROXY: 'https://[2001:db8::7]:8443',
     https_proxy: 'https://[2001:db8::7]:8443',
+    ALL_PROXY: 'https://[2001:db8::7]:8443',
+    all_proxy: 'https://[2001:db8::7]:8443',
     NO_PROXY: '',
     no_proxy: ''
   })
@@ -37,7 +39,7 @@ test('disables malformed persisted custom proxy settings instead of restoring th
   assert.deepEqual(
     proxy.readPersistedDownloadProxySettings?.({
       enabled: true,
-      protocol: 'socks5',
+      protocol: 'socks4',
       host: 'proxy.example.com',
       port: 1080
     }),
@@ -75,9 +77,10 @@ test('normalizes valid DNS, IPv4, and IPv6 proxy addresses', () => {
   )
 })
 
-test('rejects proxy values that cannot identify an HTTP or HTTPS proxy', () => {
+test('rejects proxy values that cannot identify a supported proxy', () => {
   for (const [value, message] of [
-    [{ enabled: true, protocol: 'socks5', host: 'proxy.example.com', port: 1080 }, /HTTP or HTTPS/],
+    [{ enabled: true, protocol: 'socks4', host: 'proxy.example.com', port: 1080 }, /HTTP, HTTPS, or SOCKS5/],
+    [{ enabled: true, protocol: 'http', host: 'proxy.example.com', port: 8080, password: 'p' }, /password requires a username/],
     [{ enabled: true, protocol: 'http', host: 'https://proxy.example.com', port: 8080 }, /host only/],
     [{ enabled: true, protocol: 'http', host: 'proxy.example.com/path', port: 8080 }, /host only/],
     [{ enabled: true, protocol: 'http', host: 'name@example.com', port: 8080 }, /host only/],
@@ -158,4 +161,54 @@ test('keeps resume mirror selection and proxy environment on one routing snapsho
   assert.deepEqual(proxy.selectGameArchiveMirror?.(route, activeMirror), activeMirror)
   assert.equal(environment?.HTTP_PROXY, 'http://system.example:3128')
   assert.equal(environment?.RCLONE_HEADER, 'X-API-Key: api-key')
+})
+
+test('normalizes a SOCKS5 proxy with credentials', () => {
+  assert.deepEqual(
+    proxy.normalizeDownloadProxySettings?.({
+      enabled: true,
+      protocol: 'SOCKS5',
+      host: 'proxy.example.com',
+      port: 1080,
+      username: '  user  ',
+      password: ' p@ss:word '
+    }),
+    {
+      enabled: true,
+      protocol: 'socks5',
+      host: 'proxy.example.com',
+      port: 1080,
+      username: 'user',
+      password: ' p@ss:word ' // password preserved verbatim, only username trimmed
+    }
+  )
+})
+
+test('routes SOCKS5 through ALL_PROXY with percent-encoded credentials', () => {
+  const environment = proxy.buildRcloneDownloadEnvironment?.(
+    {
+      enabled: true,
+      protocol: 'socks5',
+      host: 'proxy.example.com',
+      port: 1080,
+      username: 'user name',
+      password: 'p@ss:word'
+    },
+    { PATH: '/usr/bin', ALL_PROXY: 'socks5://inherited.example:1080' }
+  )
+
+  const url = 'socks5://user%20name:p%40ss%3Aword@proxy.example.com:1080'
+  assert.equal(environment?.ALL_PROXY, url)
+  assert.equal(environment?.all_proxy, url)
+  assert.equal(environment?.HTTP_PROXY, url)
+  assert.equal(environment?.HTTPS_PROXY, url)
+  assert.equal(environment?.NO_PROXY, '')
+})
+
+test('omits credentials from the proxy URL when no username is set', () => {
+  const environment = proxy.buildRcloneDownloadEnvironment?.(
+    { enabled: true, protocol: 'http', host: 'proxy.example.com', port: 8080 },
+    { PATH: '/usr/bin' }
+  )
+  assert.equal(environment?.HTTP_PROXY, 'http://proxy.example.com:8080')
 })

--- a/src/main/services/download/downloadProxy.ts
+++ b/src/main/services/download/downloadProxy.ts
@@ -27,8 +27,8 @@ export function normalizeDownloadProxySettings(value: ProxySettingsInput): Downl
 
   const enabled = value.enabled === true
   const protocol = typeof value.protocol === 'string' ? value.protocol.trim().toLowerCase() : 'http'
-  if (protocol !== 'http' && protocol !== 'https') {
-    throw new Error('Proxy protocol must be HTTP or HTTPS.')
+  if (protocol !== 'http' && protocol !== 'https' && protocol !== 'socks5') {
+    throw new Error('Proxy protocol must be HTTP, HTTPS, or SOCKS5.')
   }
 
   const host = typeof value.host === 'string' ? value.host.trim() : ''
@@ -36,9 +36,26 @@ export function normalizeDownloadProxySettings(value: ProxySettingsInput): Downl
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error('Proxy port must be an integer from 1 through 65535.')
   }
+
+  // Credentials are optional. Username is trimmed like a hostname; the password
+  // is taken verbatim since it may legitimately contain leading/trailing spaces.
+  const username = typeof value.username === 'string' ? value.username.trim() : ''
+  const password = typeof value.password === 'string' ? value.password : ''
+  if (password && !username) {
+    throw new Error('Proxy password requires a username.')
+  }
+
   if (enabled) validateProxyHost(host)
 
-  return { enabled, protocol, host, port }
+  const normalized: DownloadProxySettings = {
+    enabled,
+    protocol: protocol as DownloadProxySettings['protocol'],
+    host,
+    port
+  }
+  if (username) normalized.username = username
+  if (password) normalized.password = password
+  return normalized
 }
 
 export function readPersistedDownloadProxySettings(value: unknown): DownloadProxySettings {
@@ -74,7 +91,7 @@ export function buildRcloneDownloadEnvironment(
   if (!normalized.enabled) return environment
 
   for (const key of Object.keys(environment)) {
-    if (['http_proxy', 'https_proxy', 'no_proxy'].includes(key.toLowerCase())) {
+    if (['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy'].includes(key.toLowerCase())) {
       delete environment[key]
     }
   }
@@ -84,6 +101,11 @@ export function buildRcloneDownloadEnvironment(
   environment.http_proxy = proxyUrl
   environment.HTTPS_PROXY = proxyUrl
   environment.https_proxy = proxyUrl
+  // SOCKS5 is dialed from ALL_PROXY, which rclone's Go HTTP transport honors for
+  // every scheme; it's harmless for HTTP/HTTPS proxies, where the scheme-specific
+  // variables above take precedence.
+  environment.ALL_PROXY = proxyUrl
+  environment.all_proxy = proxyUrl
   environment.NO_PROXY = ''
   environment.no_proxy = ''
   return environment
@@ -119,7 +141,7 @@ export function selectGameArchiveMirror(
 
 function validateProxyHost(host: string): void {
   if (!host) throw new Error('Proxy host is required when custom proxy routing is enabled.')
-  if (host.includes('://') || /[/?#@\[\]]/.test(host)) {
+  if (host.includes('://') || /[/?#@[\]]/.test(host)) {
     throw new Error('Proxy host only accepts a DNS name, IPv4 address, or IPv6 address.')
   }
   if (isIP(host) !== 0) return
@@ -135,5 +157,9 @@ function validateProxyHost(host: string): void {
 
 function buildProxyUrl(proxySettings: DownloadProxySettings): string {
   const host = isIP(proxySettings.host) === 6 ? `[${proxySettings.host}]` : proxySettings.host
-  return `${proxySettings.protocol}://${host}:${proxySettings.port}`
+  // Percent-encode credentials so a ':' or '@' in either can't break the URL.
+  const auth = proxySettings.username
+    ? `${encodeURIComponent(proxySettings.username)}:${encodeURIComponent(proxySettings.password ?? '')}@`
+    : ''
+  return `${proxySettings.protocol}://${auth}${host}:${proxySettings.port}`
 }

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -1702,14 +1702,21 @@ const DownloadProxySettingsPanel: React.FC = () => {
             selectedOptions={[settings.protocol]}
             value={settings.protocol.toUpperCase()}
             onOptionSelect={(_, data) => {
-              if (data.optionValue === 'http' || data.optionValue === 'https') {
-                updateSettings((current) => ({ ...current, protocol: data.optionValue }))
+              // Hoist into a const so the narrowing survives into the closure below.
+              const nextProtocol = data.optionValue
+              if (
+                nextProtocol === 'http' ||
+                nextProtocol === 'https' ||
+                nextProtocol === 'socks5'
+              ) {
+                updateSettings((current) => ({ ...current, protocol: nextProtocol }))
               }
             }}
             disabled={!settings.enabled}
           >
             <Option value="http">{'HTTP'}</Option>
             <Option value="https">{'HTTPS'}</Option>
+            <Option value="socks5">{'SOCKS5'}</Option>
           </Dropdown>
         </div>
         <div className={styles.speedControl}>
@@ -1738,6 +1745,31 @@ const DownloadProxySettingsPanel: React.FC = () => {
         <Button appearance="primary" onClick={save} disabled={isSaving}>
           {isSaving ? 'Saving...' : 'Save Proxy'}
         </Button>
+      </div>
+      <div className={styles.speedFormRow}>
+        <div className={styles.speedControl}>
+          <Text>{'Username (optional)'}</Text>
+          <Input
+            aria-label="Proxy username"
+            value={settings.username ?? ''}
+            onChange={(_, data) =>
+              updateSettings((current) => ({ ...current, username: data.value }))
+            }
+            disabled={!settings.enabled}
+          />
+        </div>
+        <div className={styles.speedControl}>
+          <Text>{'Password'}</Text>
+          <Input
+            aria-label="Proxy password"
+            type="password"
+            value={settings.password ?? ''}
+            onChange={(_, data) =>
+              updateSettings((current) => ({ ...current, password: data.value }))
+            }
+            disabled={!settings.enabled || !settings.username}
+          />
+        </div>
       </div>
       {error && (
         <Text className={styles.error} role="alert">

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -471,13 +471,16 @@ export interface ServerConfigInfo {
 
 export type ExistingDownloadAction = 'ask' | 'reinstall' | 'redownload'
 
-export type DownloadProxyProtocol = 'http' | 'https'
+export type DownloadProxyProtocol = 'http' | 'https' | 'socks5'
 
 export interface DownloadProxySettings {
   enabled: boolean
   protocol: DownloadProxyProtocol
   host: string
   port: number
+  /** Optional proxy credentials. A password requires a username. */
+  username?: string
+  password?: string
 }
 
 export interface WindowBounds {

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -24,7 +24,7 @@ import {
   BackupReportResult,
   BackupVerification,
   BackupProfile,
-  DownloadProxySettings
+  DownloadProxySettings,
   GameDescriptionRequest,
   GameDescriptionResult,
   GameDescriptionSnapshot


### PR DESCRIPTION
The HTTP/HTTPS download-proxy feature (#52) merged with a botched import conflict (missing comma in ipc.ts) that broke typecheck, plus a lint error and a typecheck:web error the PR never caught (it validated with node --test only). Fix those and extend the feature to the rest of what issue #48 asked for — SOCKS5 and proxy authentication.

Fixes carried over from #52:
* ipc.ts: restore the comma after DownloadProxySettings in the import list (this was the syntax error making main red).
* downloadProxy.ts: drop the unnecessary `\[` escape in the host regex.
* Settings.tsx: hoist the Dropdown's narrowed optionValue into a const so the narrowing survives into the update closure (typecheck:web).

New — SOCKS5 + auth:
* types: DownloadProxyProtocol gains 'socks5'; DownloadProxySettings gains optional username/password.
* normalizeDownloadProxySettings accepts socks5 and validates credentials (username trimmed, password verbatim, password requires a username).
* buildProxyUrl embeds percent-encoded credentials; buildRcloneDownloadEnvironment also sets ALL_PROXY (which rclone's Go transport uses to dial SOCKS5 for every scheme, and which is harmless for HTTP/HTTPS) and clears an inherited all_proxy.
* Settings panel: SOCKS5 option plus optional username/password inputs (password masked, enabled only once a username is entered).
* Tests: SOCKS5 normalization, ALL_PROXY routing with encoded creds, no-creds URL, password-without-username rejection; updated the two existing cases that used socks5 as an "invalid" example now that it's valid.

Validated: typecheck node+web, lint (0 errors), node --test 64/65 (1 pre-existing skip), vitest 27.

Note: the proxy password is still stored in settings.json in plaintext (as #52 stores host/port). Obfuscating it at rest with the existing keyObfuscation helper is a sensible follow-up, left out here to keep this change focused.